### PR TITLE
fix/protocol 1.28 parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,177 @@
 # qualisys-go
 
-Go sdk for Qualisys Track Manager streaming of motion capture data.
+Go SDK for streaming motion capture data from Qualisys Track Manager (QTM).
 
-## Discovery example
+Zero external dependencies — only the Go standard library.
 
-```Go
-package main
+## Protocol version support
 
-import (
-	"log"
-	"time"
+The SDK speaks RT protocol **1.28** and negotiates downwards to **1.22** when
+connecting to an older QTM, mirroring the negotiation in the official
+[C++ SDK](https://github.com/qualisys/qualisys_cpp_sdk). `Connect` tries the
+newest version first and walks down the ladder; if QTM accepts none of them it
+fails with `ErrVersionNotSupported` and closes the socket.
 
-	"github.com/mlveggo/qualisys-go/pkg/discover"
+```go
+rt := qualisys.NewProtocol("192.168.0.10", qualisys.DefaultBasePort)
+if err := rt.Connect(); err != nil {
+    log.Fatal(err)
+}
+major, minor := rt.Version() // the version actually agreed on
+```
+
+Pin a version, or disable the fallback, with options:
+
+```go
+rt := qualisys.NewProtocol(addr, port,
+    qualisys.WithVersion(1, 25),
+    qualisys.WithoutVersionNegotiation(),
 )
+```
 
-func main() {
-	discovery := discover.NewDiscovery(4545, 1*time.Second)
-	responses, err := discovery.Discover()
-	if err != nil {
-		log.Println(err)
-		return
-	}
-	for _, response := range responses {
-		log.Println(response)
-	}
+Because the settings XML root element is named after the negotiated version,
+never hard-code it. Use `ParametersElementName` or `StripParametersElement`:
+
+```go
+xml, _ := rt.GetParameters(qualisys.ParameterTypeImage)
+inner := rt.StripParametersElement(xml) // drops <QTM_Parameters_Ver_X.Y>
+```
+
+## Discovery
+
+```go
+discovery := discover.NewDiscovery(4545, 1*time.Second)
+responses, err := discovery.Discover()
+if err != nil {
+    log.Fatal(err)
+}
+for _, response := range responses {
+    log.Println(response)
 }
 ```
 
-## Issues
+## Streaming
 
-- It should always fail to connect to older QTM version (Support 1.22 and
-  upwards)
-- StreamFrames - Missing support for [:channels] handling.
+```go
+rt := qualisys.NewProtocol(ip, qualisys.DefaultBasePort)
+if err := rt.Connect(); err != nil {
+    log.Fatal(err)
+}
+defer rt.Disconnect()
+
+if err := rt.StreamFramesAll(qualisys.ComponentType3D, qualisys.ComponentType6D); err != nil {
+    log.Fatal(err)
+}
+
+for {
+    p, err := rt.Receive()
+    if err != nil {
+        log.Fatal(err)
+    }
+    if p.EndOfData() {
+        continue // nothing arrived within the read timeout
+    }
+    if markers := p.Data.Markers3D(); markers != nil {
+        log.Printf("frame %d: %d markers", p.Data.Frame, len(markers.Markers))
+    }
+}
+```
+
+### Component options
+
+Analog channel selection and global skeleton coordinates are supported:
+
+```go
+opts := qualisys.ComponentOptions{
+    AnalogChannels: "1,3,5-8", // sends "Analog:1,3,5-8"
+    SkeletonGlobal: true,      // sends "Skeleton:global"
+}
+rt.StreamFramesWithOptions(qualisys.StreamRateTypeFrequency, 100, opts,
+    qualisys.ComponentTypeAnalog, qualisys.ComponentTypeSkeleton)
+```
+
+### UDP streaming
+
+Keep commands on TCP and move the data stream to UDP:
+
+```go
+udpPort, err := rt.EnableUDPStream(0) // 0 lets the OS pick
+if err != nil {
+    log.Fatal(err)
+}
+rt.StreamFramesUDP(qualisys.StreamRateTypeAllFrames, 0, udpPort, "",
+    qualisys.ComponentOptions{}, qualisys.ComponentType3D)
+
+for {
+    p, err := rt.ReceiveUDP()
+    // ...
+}
+```
+
+## Timeouts
+
+Defaults are configurable per connection:
+
+```go
+rt := qualisys.NewProtocol(ip, port,
+    qualisys.WithReadTimeout(2*time.Second),
+    qualisys.WithConnectTimeout(10*time.Second),
+    qualisys.WithMaxPacketSize(64<<20),
+)
+```
+
+`Calibrate` takes its own timeout because a calibration takes minutes:
+
+```go
+resultXML, err := rt.Calibrate(false, 5*time.Minute)
+```
+
+## Error handling
+
+Errors are wrapped and matchable with `errors.Is`:
+
+| Sentinel                 | Meaning                                                      |
+| ------------------------ | ------------------------------------------------------------ |
+| `ErrNotConnected`        | Operation needs a live connection                             |
+| `ErrTimeout`             | No response within the timeout                                |
+| `ErrTruncated`           | Packet body never fully arrived; the stream is desynchronised |
+| `ErrVersionNotSupported` | QTM accepted no version this SDK speaks                       |
+| `packets.ErrShortPacket` | A component payload ended early                               |
+
+A `Receive` timeout is *not* an error — it returns a `PacketTypeNoMoreData`
+packet with a nil error. `ErrTruncated` is different and means the connection
+must be re-established.
+
+## Forward compatibility
+
+A frame containing a component type this SDK does not recognise is still
+decoded; the unknown types are listed in `Packet.Data.Skipped` rather than
+failing the whole frame. This lets a client keep working against a newer QTM.
+
+## Examples
+
+```
+go run ./cmd/discover
+go run ./cmd/streaming -addr 192.168.0.10
+go run ./cmd/streaming -udp -analog-channels 1,3,5-8
+go run ./cmd/settings -addr 192.168.0.10
+```
+
+## Testing
+
+```
+go test ./...
+go test -race ./...
+```
+
+Tests run entirely against an in-process fake QTM server; no hardware or
+network access is required.
+
+## Known gaps versus the C++ SDK
+
+- Settings XML is exposed as raw strings plus a few helpers in `pkg/settings`.
+  The C++ SDK has full typed (de)serialisation for General, Calibration, 3D, 6D,
+  Analog, Force, Image, GazeVector, EyeTracker and Skeleton settings, including
+  the typed `Set*Settings` writers.
+- Protocol versions below 1.22 (including the big-endian-only 1.0 mode on the
+  base port) are not implemented.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Go SDK for streaming motion capture data from Qualisys Track Manager (QTM).
 
 Zero external dependencies — only the Go standard library.
 
+Every example below also exists as a testable example in `example_test.go`, so
+`go test` compiles them and they cannot drift from the API. They appear in
+[godoc](https://pkg.go.dev/github.com/mlveggo/qualisys-go) too.
+
 ## Protocol version support
 
 The SDK speaks RT protocol **1.28** and negotiates downwards to **1.22** when
@@ -77,6 +81,13 @@ for {
 }
 ```
 
+`DataPacket` has a typed accessor for every component: `Markers3D`,
+`Markers3DResidual`, `Markers3DNoLabels`, `Markers3DNoLabelsResidual`,
+`Bodies6D`, `Bodies6DResidual`, `Bodies6DEuler`, `Bodies6DEulerResidual`,
+`Markers2D`, `Markers2DLinearized`, `Analog`, `AnalogSingle`, `Force`,
+`ForceSingle`, `Images`, `GazeVectors`, `EyeTrackers`, `Timecodes` and
+`Skeletons`. Each returns nil when the frame does not carry that component.
+
 ### Component options
 
 Analog channel selection and global skeleton coordinates are supported:
@@ -140,13 +151,22 @@ Errors are wrapped and matchable with `errors.Is`:
 
 A `Receive` timeout is *not* an error — it returns a `PacketTypeNoMoreData`
 packet with a nil error. `ErrTruncated` is different and means the connection
-must be re-established.
+must be re-established. `IsTimeout` covers both `ErrTimeout` and an underlying
+socket deadline.
 
 ## Forward compatibility
 
 A frame containing a component type this SDK does not recognise is still
-decoded; the unknown types are listed in `Packet.Data.Skipped` rather than
-failing the whole frame. This lets a client keep working against a newer QTM.
+decoded, and the undecodable component keeps its raw bytes as an
+`UnknownComponent` rather than failing the whole frame. This lets a client keep
+working against a newer QTM, and lets a caller who does know the format decode
+it themselves.
+
+```go
+for _, unknown := range p.Data.UnknownComponentTypes() {
+    log.Printf("component type %d could not be decoded", int(unknown))
+}
+```
 
 ## Examples
 
@@ -166,6 +186,21 @@ go test -race ./...
 
 Tests run entirely against an in-process fake QTM server; no hardware or
 network access is required.
+
+## Relationship to qualisys-rs
+
+[qualisys-rs](https://github.com/mlveggo/qualisys-rs) is the sibling Rust
+client. The two are kept feature-equivalent: same protocol version ladder, same
+component coverage, same component and parameter options, same UDP support, and
+the same treatment of undecodable components. Where the languages differ the
+APIs follow local idiom — Rust models packets as an enum and returns a
+connected client from `connect`, Go uses a struct with a type tag and separate
+`NewProtocol`/`Connect` — but the wire behaviour is identical.
+
+One deliberate asymmetry: this SDK ships two small XML helpers in
+`pkg/settings` for pulling 3D label names and 6D body names out of a settings
+response. The Rust crate exposes raw XML only, so that it keeps its single
+dependency rather than pulling in an XML parser.
 
 ## Known gaps versus the C++ SDK
 

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ resultXML, err := rt.Calibrate(false, 5*time.Minute)
 
 Errors are wrapped and matchable with `errors.Is`:
 
-| Sentinel                 | Meaning                                                      |
-| ------------------------ | ------------------------------------------------------------ |
+| Sentinel                 | Meaning                                                       |
+| ------------------------ | ------------------------------------------------------------- |
 | `ErrNotConnected`        | Operation needs a live connection                             |
 | `ErrTimeout`             | No response within the timeout                                |
 | `ErrTruncated`           | Packet body never fully arrived; the stream is desynchronised |
@@ -189,8 +189,8 @@ go test ./...
 go test -race ./...
 ```
 
-Tests run entirely against an in-process fake QTM server; no hardware or
-network access is required.
+Tests run entirely against an in-process fake QTM server; no hardware or network
+access is required.
 
 ## Relationship to qualisys-rs
 
@@ -198,14 +198,14 @@ network access is required.
 client. The two are kept feature-equivalent: same protocol version ladder, same
 component coverage, same component and parameter options, same UDP support, and
 the same treatment of undecodable components. Where the languages differ the
-APIs follow local idiom — Rust models packets as an enum and returns a
-connected client from `connect`, Go uses a struct with a type tag and separate
+APIs follow local idiom — Rust models packets as an enum and returns a connected
+client from `connect`, Go uses a struct with a type tag and separate
 `NewProtocol`/`Connect` — but the wire behaviour is identical.
 
-One deliberate asymmetry: this SDK ships two small XML helpers in
-`pkg/settings` for pulling 3D label names and 6D body names out of a settings
-response. The Rust crate exposes raw XML only, so that it keeps its single
-dependency rather than pulling in an XML parser.
+One deliberate asymmetry: this SDK ships two small XML helpers in `pkg/settings`
+for pulling 3D label names and 6D body names out of a settings response. The
+Rust crate exposes raw XML only, so that it keeps its single dependency rather
+than pulling in an XML parser.
 
 ## Known gaps versus the C++ SDK
 

--- a/README.md
+++ b/README.md
@@ -64,13 +64,15 @@ if err := rt.Connect(); err != nil {
 defer rt.Disconnect()
 
 if err := rt.StreamFramesAll(qualisys.ComponentType3D, qualisys.ComponentType6D); err != nil {
-    log.Fatal(err)
+    log.Println(err) // not log.Fatal: it would skip the deferred Disconnect
+    return
 }
 
 for {
     p, err := rt.Receive()
     if err != nil {
-        log.Fatal(err)
+        log.Println(err)
+        return
     }
     if p.EndOfData() {
         continue // nothing arrived within the read timeout
@@ -164,7 +166,10 @@ it themselves.
 
 ```go
 for _, unknown := range p.Data.UnknownComponentTypes() {
-    log.Printf("component type %d could not be decoded", int(unknown))
+    // UnknownComponentData hands over the bytes; Component returns nil for
+    // these, since it only surfaces components the SDK decoded itself.
+    raw := p.Data.UnknownComponentData(unknown)
+    log.Printf("component type %d could not be decoded, %d raw bytes kept", int(unknown), len(raw))
 }
 ```
 

--- a/cmd/discover/main.go
+++ b/cmd/discover/main.go
@@ -1,6 +1,8 @@
+// Command discover broadcasts for QTM instances on the local network.
 package main
 
 import (
+	"flag"
 	"log"
 	"time"
 
@@ -8,10 +10,17 @@ import (
 )
 
 func main() {
-	discovery := discover.NewDiscovery(4545, 1*time.Second)
+	port := flag.Int("port", 4545, "local UDP port to receive discovery responses on")
+	timeout := flag.Duration("timeout", 1*time.Second, "how long to wait for responses")
+	flag.Parse()
+
+	discovery := discover.NewDiscovery(uint16(*port), *timeout)
 	responses, err := discovery.Discover()
 	if err != nil {
-		log.Println(err)
+		log.Fatal(err)
+	}
+	if len(responses) == 0 {
+		log.Println("No QTM instances responded")
 		return
 	}
 	for _, response := range responses {

--- a/cmd/discover/main.go
+++ b/cmd/discover/main.go
@@ -15,6 +15,11 @@ func main() {
 	flag.Parse()
 
 	discovery := discover.NewDiscovery(uint16(*port), *timeout)
+	// A command is the right place to write to the process logger; the library
+	// reports malformed replies through this hook instead of logging itself.
+	discovery.OnMalformedResponse = func(addr string, err error) {
+		log.Printf("ignoring response from %s: %v", addr, err)
+	}
 	responses, err := discovery.Discover()
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/settings/main.go
+++ b/cmd/settings/main.go
@@ -13,6 +13,14 @@ import (
 )
 
 func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// run holds the body of main so that log.Fatal is reached only after every
+// deferred cleanup has run. Calling log.Fatal directly would skip them.
+func run() error {
 	addr := flag.String("addr", "", "QTM address; discovered by broadcast when empty")
 	port := flag.Int("port", qualisys.DefaultBasePort, "QTM base port")
 	password := flag.String("password", "", "password for TakeControl")
@@ -36,17 +44,17 @@ func main() {
 
 	log.Printf("Connecting to %s:%d", ip, basePort)
 	if err := rt.Connect(); err != nil {
-		log.Fatal(err)
+		return err
 	}
 	major, minor := rt.Version()
 	log.Printf("Connected using RT protocol version %d.%d", major, minor)
 
 	xml, err := rt.GetParameters(qualisys.ParameterTypeImage)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	if err := rt.TakeControl(*password); err != nil {
-		log.Fatal(err)
+		return err
 	}
 	defer func() { _ = rt.ReleaseControl() }()
 
@@ -57,16 +65,16 @@ func main() {
 	inner = strings.ReplaceAll(inner, "<Enabled>false</Enabled>", "<Enabled>true</Enabled>")
 
 	if err := rt.SetParameters(inner); err != nil {
-		log.Fatal(err)
+		return err
 	}
 	if err := rt.StreamFramesAll(qualisys.ComponentTypeImage); err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	for {
 		p, err := rt.Receive()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		if p.EndOfData() {
 			continue

--- a/cmd/settings/main.go
+++ b/cmd/settings/main.go
@@ -1,66 +1,78 @@
+// Command settings connects to QTM, enables all image cameras and streams the
+// resulting images.
 package main
 
 import (
+	"flag"
 	"log"
-	"strconv"
 	"strings"
 	"time"
 
-	"github.com/mlveggo/qualisys-go"
+	qualisys "github.com/mlveggo/qualisys-go"
 	"github.com/mlveggo/qualisys-go/pkg/discover"
 )
 
 func main() {
-	discovery := discover.NewDiscovery(4545, 1*time.Second)
-	responses, err := discovery.Discover()
-	ip := "127.0.0.1"
-	basePort := qualisys.DefaultLittleEndianPort
-	if err == nil {
-		for _, response := range responses {
-			log.Println("Using the first found QTM: ", response)
-			ip = response.Address
-			basePort = response.BasePort
-			break
+	addr := flag.String("addr", "", "QTM address; discovered by broadcast when empty")
+	port := flag.Int("port", qualisys.DefaultBasePort, "QTM base port")
+	password := flag.String("password", "", "password for TakeControl")
+	flag.Parse()
+
+	ip, basePort := *addr, *port
+	if ip == "" {
+		ip, basePort = "127.0.0.1", qualisys.DefaultBasePort
+		discovery := discover.NewDiscovery(4545, 1*time.Second)
+		if responses, err := discovery.Discover(); err == nil {
+			for _, response := range responses {
+				log.Println("Using the first QTM found:", response)
+				ip, basePort = response.Address, response.BasePort
+				break
+			}
 		}
 	}
+
 	rt := qualisys.NewProtocol(ip, basePort)
-	log.Println("Connecting to:", ip)
+	defer rt.Disconnect()
+
+	log.Printf("Connecting to %s:%d", ip, basePort)
 	if err := rt.Connect(); err != nil {
-		log.Println(err)
-		return
+		log.Fatal(err)
 	}
+	major, minor := rt.Version()
+	log.Printf("Connected using RT protocol version %d.%d", major, minor)
+
 	xml, err := rt.GetParameters(qualisys.ParameterTypeImage)
 	if err != nil {
-		log.Println(err)
-		return
+		log.Fatal(err)
 	}
-	if err := rt.TakeControl(""); err != nil {
-		log.Println(err)
-		return
+	if err := rt.TakeControl(*password); err != nil {
+		log.Fatal(err)
 	}
-	// Note: This relies on QTM connection using RT version 1.22.
-	xml = strings.Replace(xml, "<QTM_Parameters_Ver_1.22>", "", 1)
-	xml = strings.Replace(xml, "</QTM_Parameters_Ver_1.22>", "", 1)
-	xml = strings.Replace(xml, "<Enabled>false", "<Enabled>true", 10)
-	if err := rt.SetParameters(xml); err != nil {
-		log.Println()
+	defer func() { _ = rt.ReleaseControl() }()
+
+	// The settings root element is named after the negotiated protocol version,
+	// so it must not be hard-coded. StripParametersElement removes whichever
+	// version was actually agreed on.
+	inner := rt.StripParametersElement(xml)
+	inner = strings.ReplaceAll(inner, "<Enabled>false</Enabled>", "<Enabled>true</Enabled>")
+
+	if err := rt.SetParameters(inner); err != nil {
+		log.Fatal(err)
 	}
 	if err := rt.StreamFramesAll(qualisys.ComponentTypeImage); err != nil {
-		log.Println(err)
-		return
+		log.Fatal(err)
 	}
+
 	for {
 		p, err := rt.Receive()
-		if p.EndOfData() {
-			time.Sleep(200 * time.Millisecond)
-			continue
+		if err != nil {
+			log.Fatal(err)
 		}
-		if err != nil || p.Error() {
-			log.Println(err)
+		if p.EndOfData() {
 			continue
 		}
 		for _, c := range p.Data.Components {
-			log.Println("Frame:", strconv.Itoa(int(p.Data.Frame)), c)
+			log.Printf("Frame %d: %v", p.Data.Frame, c)
 		}
 	}
 }

--- a/cmd/streaming/main.go
+++ b/cmd/streaming/main.go
@@ -1,82 +1,128 @@
+// Command streaming connects to QTM and prints streamed data frames.
 package main
 
 import (
+	"context"
+	"errors"
+	"flag"
 	"log"
 	"os"
-	"strconv"
+	"os/signal"
+	"syscall"
 	"time"
 
-	"github.com/mlveggo/qualisys-go"
+	qualisys "github.com/mlveggo/qualisys-go"
 	"github.com/mlveggo/qualisys-go/pkg/discover"
 )
 
-func HandlePackets(p *qualisys.Packet) {
+func handlePacket(p *qualisys.Packet) bool {
 	switch p.Type {
 	case qualisys.PacketTypeEvent:
 		log.Println("Event:", p.Event)
 		if p.Event == qualisys.EventTypeQTMShuttingDown {
-			os.Exit(0)
+			return false
 		}
 	case qualisys.PacketTypeData:
 		for _, c := range p.Data.Components {
-			log.Println("Frame:", strconv.Itoa(int(p.Data.Frame)), c)
+			log.Printf("Frame %d: %v", p.Data.Frame, c)
+		}
+		// Components this build of the SDK does not recognise are reported
+		// rather than silently discarding the whole frame.
+		for _, skipped := range p.Data.Skipped {
+			log.Printf("Frame %d: skipped unknown component type %d", p.Data.Frame, skipped)
 		}
 	}
+	return true
+}
+
+func findQTM() (string, int) {
+	discovery := discover.NewDiscovery(4545, 1*time.Second)
+	responses, err := discovery.Discover()
+	if err != nil {
+		log.Println("discovery failed:", err)
+		return "127.0.0.1", qualisys.DefaultBasePort
+	}
+	for _, response := range responses {
+		log.Println("Using the first QTM found:", response)
+		return response.Address, response.BasePort
+	}
+	return "127.0.0.1", qualisys.DefaultBasePort
 }
 
 func main() {
-	ip := "127.0.0.1"
-	basePort := qualisys.DefaultLittleEndianPort
-	if len(os.Args) <= 1 {
-		discovery := discover.NewDiscovery(4545, 1*time.Second)
-		responses, err := discovery.Discover()
-		if err == nil {
-			for _, response := range responses {
-				log.Println("Using the first found QTM: ", response)
-				ip = response.Address
-				basePort = response.BasePort
-				break
-			}
-		}
-	} else {
-		ip = os.Args[1]
+	addr := flag.String("addr", "", "QTM address; discovered by broadcast when empty")
+	port := flag.Int("port", qualisys.DefaultBasePort, "QTM base port")
+	useUDP := flag.Bool("udp", false, "stream data over UDP instead of the TCP control connection")
+	channels := flag.String("analog-channels", "", "restrict analog streaming to these channels, e.g. 1,3,5-8")
+	flag.Parse()
+
+	ip, basePort := *addr, *port
+	if ip == "" {
+		ip, basePort = findQTM()
 	}
-	log.Println("Connecting to: ", ip)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	rt := qualisys.NewProtocol(ip, basePort)
-	parametersFetched := false
-	streaming := false
+	defer rt.Disconnect()
+
+	log.Printf("Connecting to %s:%d", ip, basePort)
+	if err := rt.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	major, minor := rt.Version()
+	log.Printf("Connected using RT protocol version %d.%d", major, minor)
+
+	if version, err := rt.GetQTMVersion(); err == nil {
+		log.Println("QTM version:", version)
+	}
+
+	opts := qualisys.ComponentOptions{AnalogChannels: *channels}
+	components := []qualisys.ComponentType{qualisys.ComponentType6DEulerResidual}
+
+	receive := rt.Receive
+	if *useUDP {
+		udpPort, err := rt.EnableUDPStream(0)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("Receiving data on UDP port %d", udpPort)
+		if err := rt.StreamFramesUDP(qualisys.StreamRateTypeAllFrames, 0, udpPort, "", opts, components...); err != nil {
+			log.Fatal(err)
+		}
+		receive = rt.ReceiveUDP
+	} else {
+		if err := rt.StreamFramesWithOptions(qualisys.StreamRateTypeAllFrames, 0, opts, components...); err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	for {
-		if !rt.IsConnected() {
-			if err := rt.Connect(); err != nil {
-				log.Println(err)
-				continue
-			}
+		select {
+		case <-ctx.Done():
+			log.Println("Shutting down")
+			_ = rt.StreamFramesStop()
+			return
+		default:
 		}
-		if !parametersFetched {
-			_, err := rt.GetParameters(qualisys.ParameterType6D)
-			if err != nil {
-				log.Println(err)
-				continue
-			}
-			parametersFetched = true
-		}
-		if !streaming {
-			if err := rt.StreamFramesAll(qualisys.ComponentType6DEulerResidual); err != nil {
-				log.Println(err)
-				continue
-			}
-		}
-		for {
-			p, err := rt.Receive()
-			if p.EndOfData() {
-				time.Sleep(200 * time.Millisecond)
-				continue
-			}
-			if err != nil || p.Error() {
-				log.Println(err)
+
+		p, err := receive()
+		if err != nil {
+			// A truncated packet desynchronises the stream; the connection has
+			// to be rebuilt rather than limped along.
+			if errors.Is(err, qualisys.ErrTruncated) {
+				log.Println("stream desynchronised, reconnecting:", err)
 				return
 			}
-			HandlePackets(p)
+			log.Println(err)
+			return
+		}
+		if p.EndOfData() {
+			continue
+		}
+		if !handlePacket(p) {
+			return
 		}
 	}
 }

--- a/cmd/streaming/main.go
+++ b/cmd/streaming/main.go
@@ -26,10 +26,10 @@ func handlePacket(p *qualisys.Packet) bool {
 		for _, c := range p.Data.Components {
 			log.Printf("Frame %d: %v", p.Data.Frame, c)
 		}
-		// Components this build of the SDK does not recognise are reported
-		// rather than silently discarding the whole frame.
-		for _, skipped := range p.Data.Skipped {
-			log.Printf("Frame %d: skipped unknown component type %d", p.Data.Frame, skipped)
+		// Components this build of the SDK does not recognise keep their raw
+		// bytes rather than being discarded with the rest of the frame.
+		for _, unknown := range p.Data.UnknownComponentTypes() {
+			log.Printf("Frame %d: undecodable component type %d", p.Data.Frame, unknown)
 		}
 	}
 	return true

--- a/cmd/streaming/main.go
+++ b/cmd/streaming/main.go
@@ -26,7 +26,7 @@ func handlePacket(p *qualisys.Packet) bool {
 		for _, c := range p.Data.Components {
 			log.Printf("Frame %d: %v", p.Data.Frame, c)
 		}
-		// Components this build of the SDK does not recognise keep their raw
+		// Components this build of the SDK does not recognize keep their raw
 		// bytes rather than being discarded with the rest of the frame.
 		for _, unknown := range p.Data.UnknownComponentTypes() {
 			log.Printf("Frame %d: undecodable component type %d", p.Data.Frame, unknown)
@@ -50,6 +50,14 @@ func findQTM() (string, int) {
 }
 
 func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// run holds the body of main so that log.Fatal is reached only after every
+// deferred cleanup has run. Calling log.Fatal directly would skip them.
+func run() error {
 	addr := flag.String("addr", "", "QTM address; discovered by broadcast when empty")
 	port := flag.Int("port", qualisys.DefaultBasePort, "QTM base port")
 	useUDP := flag.Bool("udp", false, "stream data over UDP instead of the TCP control connection")
@@ -69,7 +77,7 @@ func main() {
 
 	log.Printf("Connecting to %s:%d", ip, basePort)
 	if err := rt.Connect(); err != nil {
-		log.Fatal(err)
+		return err
 	}
 	major, minor := rt.Version()
 	log.Printf("Connected using RT protocol version %d.%d", major, minor)
@@ -85,16 +93,20 @@ func main() {
 	if *useUDP {
 		udpPort, err := rt.EnableUDPStream(0)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		log.Printf("Receiving data on UDP port %d", udpPort)
-		if err := rt.StreamFramesUDP(qualisys.StreamRateTypeAllFrames, 0, udpPort, "", opts, components...); err != nil {
-			log.Fatal(err)
+		if err := rt.StreamFramesUDP(
+			qualisys.StreamRateTypeAllFrames, 0, udpPort, "", opts, components...,
+		); err != nil {
+			return err
 		}
 		receive = rt.ReceiveUDP
 	} else {
-		if err := rt.StreamFramesWithOptions(qualisys.StreamRateTypeAllFrames, 0, opts, components...); err != nil {
-			log.Fatal(err)
+		if err := rt.StreamFramesWithOptions(
+			qualisys.StreamRateTypeAllFrames, 0, opts, components...,
+		); err != nil {
+			return err
 		}
 	}
 
@@ -103,7 +115,7 @@ func main() {
 		case <-ctx.Done():
 			log.Println("Shutting down")
 			_ = rt.StreamFramesStop()
-			return
+			return nil
 		default:
 		}
 
@@ -113,16 +125,15 @@ func main() {
 			// to be rebuilt rather than limped along.
 			if errors.Is(err, qualisys.ErrTruncated) {
 				log.Println("stream desynchronised, reconnecting:", err)
-				return
+				return nil
 			}
-			log.Println(err)
-			return
+			return err
 		}
 		if p.EndOfData() {
 			continue
 		}
 		if !handlePacket(p) {
-			return
+			return nil
 		}
 	}
 }

--- a/commands.go
+++ b/commands.go
@@ -1,63 +1,130 @@
 package qualisys
 
 import (
-	"encoding/binary"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type senderType func(string) error
 
-func (rt *Protocol) sendCommand(cmd string) error {
+// sendString frames and writes a null-terminated string packet.
+//
+// The header is written in the connection's byte order. The previous
+// implementation always wrote a little-endian header, which meant a big-endian
+// connection could receive but never successfully send.
+func (rt *Protocol) sendString(s string, t PacketType) error {
 	if !rt.IsConnected() {
-		return fmt.Errorf("sendcommand: not connected")
+		return ErrNotConnected
 	}
-	const packetHeaderSize = 8
-	dataSize := len(cmd) + packetHeaderSize + 1
+	dataSize := len(s) + packetHeaderSize + 1
 	data := make([]byte, dataSize)
-	binary.LittleEndian.PutUint32(data, uint32(dataSize))
-	binary.LittleEndian.PutUint32(data[4:8], uint32(PacketTypeCommand))
-	copy(data[8:dataSize], cmd+"\x00")
+	rt.order.PutUint32(data[0:4], uint32(dataSize))
+	rt.order.PutUint32(data[4:8], uint32(t))
+	copy(data[packetHeaderSize:], s)
+	// The final byte is already zero, providing the terminator.
 	if _, err := rt.conn.Write(data); err != nil {
-		return fmt.Errorf("sendcommand: write failed: %w", err)
+		return fmt.Errorf("write failed: %w", err)
+	}
+	return nil
+}
+
+func (rt *Protocol) sendCommand(cmd string) error {
+	if err := rt.sendString(cmd, PacketTypeCommand); err != nil {
+		return fmt.Errorf("sendcommand: %w", err)
 	}
 	return nil
 }
 
 func (rt *Protocol) sendXML(cmd string) error {
-	if !rt.IsConnected() {
-		return fmt.Errorf("sendxml: not connected")
-	}
-	const packetHeaderSize = 8
-	dataSize := len(cmd) + packetHeaderSize + 1
-	data := make([]byte, dataSize)
-	binary.LittleEndian.PutUint32(data, uint32(dataSize))
-	binary.LittleEndian.PutUint32(data[4:8], uint32(PacketTypeXML))
-	copy(data[8:dataSize], cmd+"\x00")
-	if _, err := rt.conn.Write(data); err != nil {
-		return fmt.Errorf("sendxml: write failed: %w", err)
+	if err := rt.sendString(cmd, PacketTypeXML); err != nil {
+		return fmt.Errorf("sendxml: %w", err)
 	}
 	return nil
 }
 
+// SendCommand sends a raw command and returns QTM's response string. It is
+// exposed so callers can reach protocol features this SDK has not wrapped yet.
+func (rt *Protocol) SendCommand(cmd string) (string, error) {
+	if err := rt.sendCommand(cmd); err != nil {
+		return "", err
+	}
+	p, err := rt.receiveSkippingEvents(DefaultCommandTimeout)
+	if err != nil {
+		return "", fmt.Errorf("sendcommand %q: %w", cmd, err)
+	}
+	return p.CommandResponse, nil
+}
+
+// SetVersion negotiates a specific protocol version. On success the negotiated
+// version is recorded and returned by Version.
 func (rt *Protocol) SetVersion(major, minor int) error {
 	ver := strconv.Itoa(major) + "." + strconv.Itoa(minor)
 	cmd := "Version " + ver
 	qtmResponses := []string{"Version set to " + ver}
 	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, qtmResponses); err != nil {
-		return fmt.Errorf("start: %w", err)
+		return fmt.Errorf("setversion %s: %w", ver, err)
+	}
+	rt.majorVersion = major
+	rt.minorVersion = minor
+	return nil
+}
+
+// GetQTMVersion returns the QTM application version string.
+func (rt *Protocol) GetQTMVersion() (string, error) {
+	resp, err := rt.SendCommand("QTMVersion")
+	if err != nil {
+		return "", fmt.Errorf("getqtmversion: %w", err)
+	}
+	return resp, nil
+}
+
+// GetByteOrder asks QTM which byte order the current connection uses.
+func (rt *Protocol) GetByteOrder() (bigEndian bool, err error) {
+	resp, err := rt.SendCommand("ByteOrder")
+	if err != nil {
+		return false, fmt.Errorf("getbyteorder: %w", err)
+	}
+	return resp == "Byte order is big endian", nil
+}
+
+// CheckLicense validates a license code against QTM.
+func (rt *Protocol) CheckLicense(licenseCode string) error {
+	resp, err := rt.SendCommand("CheckLicense " + licenseCode)
+	if err != nil {
+		return fmt.Errorf("checklicense: %w", err)
+	}
+	if resp != "License pass" {
+		return fmt.Errorf("checklicense: rejected (%s)", resp)
 	}
 	return nil
 }
 
-// GetState makes QTM send the current state as an event.
-func (rt *Protocol) GetState() error {
+// GetState asks QTM for its current state and returns the resulting event.
+//
+// The previous implementation only sent the command and left the reply for
+// whoever called Receive next, so there was no way to actually read the state.
+func (rt *Protocol) GetState() (EventType, error) {
 	cmd := "GetState"
-	if err := rt.sendCommand(cmd); err != nil {
-		return fmt.Errorf("getstate: %w", err)
+	if rt.majorVersion == 1 && rt.minorVersion <= 9 {
+		cmd = "GetLastEvent"
 	}
-	return nil
+	if err := rt.sendCommand(cmd); err != nil {
+		return EventTypeNone, fmt.Errorf("getstate: %w", err)
+	}
+	deadline := time.Now().Add(DefaultCommandTimeout)
+	for time.Now().Before(deadline) {
+		p, err := rt.ReceiveTimeout(time.Until(deadline))
+		if err != nil {
+			return EventTypeNone, fmt.Errorf("getstate: %w", err)
+		}
+		if p.Type == PacketTypeEvent {
+			return p.Event, nil
+		}
+	}
+	return EventTypeNone, fmt.Errorf("getstate: %w", ErrTimeout)
 }
 
 //go:generate stringer -type StreamRateType -trimprefix StreamRateType
@@ -69,78 +136,234 @@ const (
 	StreamRateTypeFrequencyDivisor
 )
 
-func (rt Protocol) getComponentString(c ComponentType) string {
-	componentsToString := map[ComponentType]string{
-		ComponentType3D:                 "3D",
-		ComponentType3DNoLabels:         "3DNoLabels",
-		ComponentTypeAnalog:             "Analog",
-		ComponentTypeForce:              "Force",
-		ComponentType6D:                 "6D",
-		ComponentType6DEuler:            "6DEuler",
-		ComponentType2D:                 "2D",
-		ComponentType2DLinearized:       "2DLin",
-		ComponentType3DResidual:         "3DRes",
-		ComponentType3DNoLabelsResidual: "3dNoLabelsResidual",
-		ComponentType6DResidual:         "6DRes",
-		ComponentType6DEulerResidual:    "6DEulerRes",
-		ComponentTypeAnalogSingle:       "AnalogSingle",
-		ComponentTypeImage:              "Image",
-		ComponentTypeForceSingle:        "ForceSingle",
-		ComponentTypeGazeVector:         "GazeVector",
-		ComponentTypeTimecode:           "Timecode",
-		ComponentTypeSkeleton:           "Skeleton",
-		ComponentTypeEyeTracker:         "EyeTracker",
-	}
-	return componentsToString[c]
+// ComponentOptions carries the per-component modifiers the RT protocol accepts
+// after a colon. Both were previously unsupported, and were listed as known
+// gaps in the project README.
+type ComponentOptions struct {
+	// AnalogChannels limits Analog and AnalogSingle streams to specific
+	// channels, for example "1,3,5-8". Empty means all channels.
+	AnalogChannels string
+	// SkeletonGlobal requests skeleton segment positions and rotations in the
+	// global coordinate system rather than relative to the parent segment.
+	SkeletonGlobal bool
 }
 
-func (rt *Protocol) GetCurrentFrame(components ...ComponentType) error {
-	cmd := "GetCurrentFrame"
+// componentNames maps each component to the token QTM accepts on the wire.
+//
+// ComponentType3DNoLabelsResidual previously mapped to "3dNoLabelsResidual",
+// which QTM does not recognise -- the accepted token is "3DNoLabelsRes", so
+// requesting that component silently produced no data.
+var componentNames = map[ComponentType]string{
+	ComponentType3D:                 "3D",
+	ComponentType3DNoLabels:         "3DNoLabels",
+	ComponentTypeAnalog:             "Analog",
+	ComponentTypeForce:              "Force",
+	ComponentType6D:                 "6D",
+	ComponentType6DEuler:            "6DEuler",
+	ComponentType2D:                 "2D",
+	ComponentType2DLinearized:       "2DLin",
+	ComponentType3DResidual:         "3DRes",
+	ComponentType3DNoLabelsResidual: "3DNoLabelsRes",
+	ComponentType6DResidual:         "6DRes",
+	ComponentType6DEulerResidual:    "6DEulerRes",
+	ComponentTypeAnalogSingle:       "AnalogSingle",
+	ComponentTypeImage:              "Image",
+	ComponentTypeForceSingle:        "ForceSingle",
+	ComponentTypeGazeVector:         "GazeVector",
+	ComponentTypeTimecode:           "Timecode",
+	ComponentTypeSkeleton:           "Skeleton",
+	ComponentTypeEyeTracker:         "EyeTracker",
+}
+
+func (rt Protocol) getComponentString(c ComponentType) string {
+	return componentNames[c]
+}
+
+// componentString renders a component list with any applicable options.
+func componentString(opts ComponentOptions, components ...ComponentType) (string, error) {
+	parts := make([]string, 0, len(components))
 	for _, c := range components {
-		cmd += " " + rt.getComponentString(c)
+		name, ok := componentNames[c]
+		if !ok {
+			return "", fmt.Errorf("unknown component type %d", int(c))
+		}
+		switch c {
+		case ComponentTypeAnalog, ComponentTypeAnalogSingle:
+			if opts.AnalogChannels != "" {
+				name += ":" + opts.AnalogChannels
+			}
+		case ComponentTypeSkeleton:
+			if opts.SkeletonGlobal {
+				name += ":global"
+			}
+		}
+		parts = append(parts, name)
 	}
-	if err := rt.sendCommand(cmd); err != nil {
+	return strings.Join(parts, " "), nil
+}
+
+// GetCurrentFrame requests a single frame containing the given components.
+func (rt *Protocol) GetCurrentFrame(components ...ComponentType) error {
+	return rt.GetCurrentFrameWithOptions(ComponentOptions{}, components...)
+}
+
+// GetCurrentFrameWithOptions requests a single frame with component options.
+func (rt *Protocol) GetCurrentFrameWithOptions(opts ComponentOptions, components ...ComponentType) error {
+	cs, err := componentString(opts, components...)
+	if err != nil {
+		return fmt.Errorf("getcurrentframe: %w", err)
+	}
+	if err := rt.sendCommand("GetCurrentFrame " + cs); err != nil {
 		return fmt.Errorf("getcurrentframe: %w", err)
 	}
 	return nil
 }
 
+// StreamFramesAll streams every frame over the existing TCP connection.
 func (rt *Protocol) StreamFramesAll(components ...ComponentType) error {
-	if err := rt.StreamFrames(StreamRateTypeAllFrames, 0, components...); err != nil {
-		return fmt.Errorf("streamframesall: %w", err)
-	}
-	return nil
+	return rt.StreamFrames(StreamRateTypeAllFrames, 0, components...)
 }
 
+// StreamFrames starts streaming over the existing TCP connection.
 func (rt *Protocol) StreamFrames(rate StreamRateType, value int, components ...ComponentType) error {
-	cmd := "StreamFrames"
+	return rt.StreamFramesWithOptions(rate, value, ComponentOptions{}, components...)
+}
+
+// StreamFramesWithOptions starts streaming with per-component options.
+func (rt *Protocol) StreamFramesWithOptions(rate StreamRateType, value int, opts ComponentOptions, components ...ComponentType) error {
+	return rt.streamFrames(rate, value, 0, "", opts, components...)
+}
+
+// StreamFramesUDP starts streaming data frames to a UDP endpoint while keeping
+// commands and responses on the TCP connection.
+//
+// udpAddr may be empty, in which case QTM sends to the address the TCP
+// connection came from. Use EnableUDPStream to have the SDK open a receiving
+// socket and then read frames with ReceiveUDP.
+func (rt *Protocol) StreamFramesUDP(rate StreamRateType, value int, udpPort int, udpAddr string, opts ComponentOptions, components ...ComponentType) error {
+	if udpPort <= 0 || udpPort > 65535 {
+		return fmt.Errorf("streamframesudp: invalid udp port %d", udpPort)
+	}
+	if len(udpAddr) > 64 {
+		return fmt.Errorf("streamframesudp: udp address too long")
+	}
+	return rt.streamFrames(rate, value, udpPort, udpAddr, opts, components...)
+}
+
+func (rt *Protocol) streamFrames(rate StreamRateType, value, udpPort int, udpAddr string, opts ComponentOptions, components ...ComponentType) error {
+	var b strings.Builder
+	b.WriteString("StreamFrames")
 	switch rate {
 	case StreamRateTypeAllFrames:
-		cmd += " allframes"
+		b.WriteString(" AllFrames")
 	case StreamRateTypeFrequency:
-		cmd += " frequency:" + strconv.Itoa(value)
+		b.WriteString(" Frequency:" + strconv.Itoa(value))
 	case StreamRateTypeFrequencyDivisor:
-		cmd += " frequencydivisor:" + strconv.Itoa(value)
+		b.WriteString(" FrequencyDivisor:" + strconv.Itoa(value))
+	default:
+		return fmt.Errorf("streamframes: invalid rate type %d", int(rate))
 	}
-	for _, c := range components {
-		cmd += " " + rt.getComponentString(c)
+
+	if udpPort > 0 {
+		b.WriteString(" UDP")
+		if udpAddr != "" {
+			b.WriteString(":" + udpAddr)
+		}
+		b.WriteString(":" + strconv.Itoa(udpPort))
 	}
-	if err := rt.sendCommand(cmd); err != nil {
+
+	cs, err := componentString(opts, components...)
+	if err != nil {
+		return fmt.Errorf("streamframes: %w", err)
+	}
+	if cs == "" {
+		return fmt.Errorf("streamframes: no components requested")
+	}
+	b.WriteString(" " + cs)
+
+	if err := rt.sendCommand(b.String()); err != nil {
 		return fmt.Errorf("streamframes: %w", err)
 	}
 	return nil
 }
 
 func (rt *Protocol) StreamFramesStop() error {
-	cmd := "StreamFrames stop"
-	if err := rt.sendCommand(cmd); err != nil {
+	if err := rt.sendCommand("StreamFrames Stop"); err != nil {
 		return fmt.Errorf("streamframesstop: %w", err)
 	}
 	return nil
 }
 
+// EnableUDPStream opens a UDP socket for receiving streamed data. Pass port 0
+// to let the operating system choose; the chosen port is returned and should be
+// passed to StreamFramesUDP.
+func (rt *Protocol) EnableUDPStream(port int) (int, error) {
+	if rt.udpConn != nil {
+		rt.udpConn.Close()
+		rt.udpConn = nil
+	}
+	addr := &net.UDPAddr{Port: port}
+	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		return 0, fmt.Errorf("enableudpstream: listen: %w", err)
+	}
+	rt.udpConn = conn
+	local, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		conn.Close()
+		rt.udpConn = nil
+		return 0, fmt.Errorf("enableudpstream: unexpected local address type")
+	}
+	return local.Port, nil
+}
+
+// UDPServerPort returns the local port of the UDP stream socket, or 0.
+func (rt *Protocol) UDPServerPort() int {
+	if rt.udpConn == nil {
+		return 0
+	}
+	if local, ok := rt.udpConn.LocalAddr().(*net.UDPAddr); ok {
+		return local.Port
+	}
+	return 0
+}
+
+// ReceiveUDP reads one datagram from the UDP stream socket and decodes it.
+//
+// Each QTM UDP datagram carries exactly one complete packet, so unlike the TCP
+// path there is no reassembly to do.
+func (rt *Protocol) ReceiveUDP() (*Packet, error) {
+	if rt.udpConn == nil {
+		return &Packet{Type: PacketTypeNone}, fmt.Errorf("receiveudp: %w: call EnableUDPStream first", ErrNotConnected)
+	}
+	if rt.readTimeout > 0 {
+		if err := rt.udpConn.SetReadDeadline(time.Now().Add(rt.readTimeout)); err != nil {
+			return &Packet{Type: PacketTypeNone}, fmt.Errorf("receiveudp: set deadline: %w", err)
+		}
+	}
+	buf := make([]byte, 65536)
+	n, _, err := rt.udpConn.ReadFromUDP(buf)
+	if err != nil {
+		if isTimeout(err) {
+			return &Packet{Type: PacketTypeNoMoreData}, nil
+		}
+		return &Packet{Type: PacketTypeNone}, fmt.Errorf("receiveudp: read: %w", err)
+	}
+	if n < packetHeaderSize {
+		return &Packet{Type: PacketTypeNone}, fmt.Errorf("receiveudp: datagram too short (%d bytes)", n)
+	}
+	p := &Packet{order: rt.order}
+	if err := p.UnmarshalBinary(buf[:n]); err != nil {
+		return &Packet{Type: PacketTypeNone}, fmt.Errorf("receiveudp: unmarshal: %w", err)
+	}
+	return p, nil
+}
+
 func (rt *Protocol) TakeControl(password string) error {
-	cmd := "TakeControl " + password
+	cmd := "TakeControl"
+	if password != "" {
+		cmd += " " + password
+	}
 	qtmResponses := []string{"You are now master", "You are already master"}
 	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, qtmResponses); err != nil {
 		return fmt.Errorf("takecontrol: %w", err)
@@ -149,28 +372,25 @@ func (rt *Protocol) TakeControl(password string) error {
 }
 
 func (rt *Protocol) ReleaseControl() error {
-	cmd := "ReleaseControl"
 	qtmResponses := []string{"You are now a regular client", "You are already a regular client"}
-	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, qtmResponses); err != nil {
+	if err := rt.sendAndWaitForResponse(rt.sendCommand, "ReleaseControl", qtmResponses); err != nil {
 		return fmt.Errorf("releasecontrol: %w", err)
 	}
 	return nil
 }
 
 func (rt *Protocol) New() error {
-	cmd := "New"
-	qtmResponses := []string{"Creating new connection"}
-	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, qtmResponses); err != nil {
+	qtmResponses := []string{"Creating new connection", "Already connected"}
+	if err := rt.sendAndWaitForResponse(rt.sendCommand, "New", qtmResponses); err != nil {
 		return fmt.Errorf("new: %w", err)
 	}
 	return nil
 }
 
 func (rt *Protocol) Close() error {
-	cmd := "Close"
-	qtmResponses := []string{"Closing connection", "Closing file"}
-	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, qtmResponses); err != nil {
-		return fmt.Errorf("start: %w", err)
+	qtmResponses := []string{"Closing connection", "File closed", "Closing file", "No connection to close"}
+	if err := rt.sendAndWaitForResponse(rt.sendCommand, "Close", qtmResponses); err != nil {
+		return fmt.Errorf("close: %w", err)
 	}
 	return nil
 }
@@ -188,18 +408,16 @@ func (rt *Protocol) Start(rtFromFile bool) error {
 }
 
 func (rt *Protocol) Stop() error {
-	cmd := "Stop"
 	qtmResponses := []string{"Stopping measurement"}
-	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, qtmResponses); err != nil {
+	if err := rt.sendAndWaitForResponse(rt.sendCommand, "Stop", qtmResponses); err != nil {
 		return fmt.Errorf("stop: %w", err)
 	}
 	return nil
 }
 
 func (rt *Protocol) Load(filename string) error {
-	cmd := "Load " + filename
 	qtmResponses := []string{"Measurement loaded"}
-	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, qtmResponses); err != nil {
+	if err := rt.sendAndWaitForResponse(rt.sendCommand, "Load "+filename, qtmResponses); err != nil {
 		return fmt.Errorf("load: %w", err)
 	}
 	return nil
@@ -218,69 +436,126 @@ func (rt *Protocol) Save(filename string, overwrite bool) error {
 }
 
 func (rt *Protocol) LoadProject(path string) error {
-	cmd := "LoadProject " + path
 	qtmResponses := []string{"Project loaded"}
-	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, qtmResponses); err != nil {
+	if err := rt.sendAndWaitForResponse(rt.sendCommand, "LoadProject "+path, qtmResponses); err != nil {
 		return fmt.Errorf("loadproject: %w", err)
 	}
 	return nil
 }
 
-func (rt *Protocol) GetCaptureC3D() error {
-	cmd := "GetCaptureC3D"
-	qtmResponses := []string{"Sending capture"}
-	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, qtmResponses); err != nil {
-		return fmt.Errorf("getcapturec3d: %w", err)
-	}
-	return nil
+// GetCaptureC3D downloads the current capture as a C3D file.
+//
+// The previous version only sent the command and returned; the file packet that
+// followed was left for an unsuspecting Receive caller, and even then
+// FilePacket decoding discarded the content. This waits for the transfer and
+// returns the bytes.
+func (rt *Protocol) GetCaptureC3D() (*FilePacket, error) {
+	return rt.getCapture("GetCaptureC3D", PacketTypeC3DFile)
 }
 
-func (rt *Protocol) GetCaptureQTM() error {
-	cmd := "GetCaptureQTM"
-	qtmResponses := []string{"Sending capture"}
-	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, qtmResponses); err != nil {
-		return fmt.Errorf("getcaptureqtm: %w", err)
+// GetCaptureQTM downloads the current capture as a QTM file.
+func (rt *Protocol) GetCaptureQTM() (*FilePacket, error) {
+	return rt.getCapture("GetCaptureQTM", PacketTypeQTMFile)
+}
+
+func (rt *Protocol) getCapture(cmd string, want PacketType) (*FilePacket, error) {
+	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, []string{"Sending capture"}); err != nil {
+		return nil, fmt.Errorf("%s: %w", strings.ToLower(cmd), err)
 	}
-	return nil
+	p, err := rt.receiveSkippingEvents(DefaultFileTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", strings.ToLower(cmd), err)
+	}
+	if p.Type != want {
+		return nil, fmt.Errorf("%s: expected packet type %v, got %v", strings.ToLower(cmd), want, p.Type)
+	}
+	file := p.File
+	return &file, nil
+}
+
+// SaveCaptureC3D downloads the current capture and writes it to path.
+func (rt *Protocol) SaveCaptureC3D(path string) error {
+	f, err := rt.GetCaptureC3D()
+	if err != nil {
+		return err
+	}
+	return f.WriteFile(path)
+}
+
+// SaveCaptureQTM downloads the current capture and writes it to path.
+func (rt *Protocol) SaveCaptureQTM(path string) error {
+	f, err := rt.GetCaptureQTM()
+	if err != nil {
+		return err
+	}
+	return f.WriteFile(path)
 }
 
 func (rt *Protocol) Trig() error {
-	cmd := "Trig"
 	qtmResponses := []string{"Trig ok"}
-	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, qtmResponses); err != nil {
+	if err := rt.sendAndWaitForResponse(rt.sendCommand, "Trig", qtmResponses); err != nil {
 		return fmt.Errorf("trig: %w", err)
 	}
 	return nil
 }
 
+// SetQTMEvent inserts a labelled event into the current measurement.
 func (rt *Protocol) SetQTMEvent(label string) error {
-	cmd := "SetQTMEvent " + label
+	// The command was renamed from "Event" in protocol version 1.8.
+	cmd := "SetQTMEvent "
+	if rt.majorVersion == 1 && rt.minorVersion <= 7 {
+		cmd = "Event "
+	}
 	qtmResponses := []string{"Event set"}
-	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, qtmResponses); err != nil {
+	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd+label, qtmResponses); err != nil {
 		return fmt.Errorf("setqtmevent: %w", err)
 	}
 	return nil
 }
 
 func (rt *Protocol) Reprocess() error {
-	cmd := "Reprocess"
 	qtmResponses := []string{"Reprocessing file"}
-	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, qtmResponses); err != nil {
+	if err := rt.sendAndWaitForResponse(rt.sendCommand, "Reprocess", qtmResponses); err != nil {
 		return fmt.Errorf("reprocess: %w", err)
 	}
 	return nil
 }
 
-func (rt *Protocol) Calibrate(refine bool) error {
+// Calibrate starts a camera calibration and waits for the resulting
+// calibration XML.
+//
+// The old implementation returned as soon as QTM acknowledged the command, so
+// the calibration result was never read and the next Receive would return it
+// unexpectedly. Calibration also takes minutes, far longer than the one second
+// read deadline that used to apply, so it could not have completed anyway.
+func (rt *Protocol) Calibrate(refine bool, timeout time.Duration) (string, error) {
+	if timeout <= 0 {
+		timeout = DefaultCalibrationTimeout
+	}
 	cmd := "Calibrate"
 	if refine {
 		cmd += " Refine"
 	}
-	qtmResponses := []string{"Starting calibration"}
-	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, qtmResponses); err != nil {
-		return fmt.Errorf("calibrate: %w", err)
+	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, []string{"Starting calibration"}); err != nil {
+		return "", fmt.Errorf("calibrate: %w", err)
 	}
-	return nil
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		p, err := rt.ReceiveTimeout(time.Until(deadline))
+		if err != nil {
+			return "", fmt.Errorf("calibrate: %w", err)
+		}
+		switch p.Type {
+		case PacketTypeXML:
+			return p.XMLResponse, nil
+		case PacketTypeEvent:
+			if p.Event == EventTypeConnectionClosed {
+				return "", fmt.Errorf("calibrate: connection closed during calibration")
+			}
+		}
+	}
+	return "", fmt.Errorf("calibrate: %w waiting for calibration result", ErrTimeout)
 }
 
 //go:generate stringer -type LedMode -trimprefix LedMode
@@ -304,32 +579,36 @@ const (
 func (rt *Protocol) Led(cameraNumber int, mode LedMode, color LedColor) error {
 	cmd := "Led " + strconv.Itoa(cameraNumber) + " " + mode.String() + " " + color.String()
 	if err := rt.sendCommand(cmd); err != nil {
-		return fmt.Errorf("stop: %w", err)
+		return fmt.Errorf("led: %w", err)
 	}
 	return nil
 }
 
 func (rt *Protocol) Quit() error {
-	cmd := "Quit"
 	qtmResponses := []string{"Bye bye"}
-	if err := rt.sendAndWaitForResponse(rt.sendCommand, cmd, qtmResponses); err != nil {
-		return fmt.Errorf("stop: %w", err)
+	if err := rt.sendAndWaitForResponse(rt.sendCommand, "Quit", qtmResponses); err != nil {
+		return fmt.Errorf("quit: %w", err)
 	}
 	return nil
 }
 
+// sendAndWaitForResponse sends a string and waits for one of the expected
+// command responses, skipping any event packets that arrive first.
 func (rt *Protocol) sendAndWaitForResponse(sender senderType, s string, expectedResponses []string) error {
 	if err := sender(s); err != nil {
-		return fmt.Errorf("sendcommandandwaitforresponse: sender: %w", err)
+		return err
 	}
-	p, err := rt.Receive()
+	p, err := rt.receiveSkippingEvents(DefaultCommandTimeout)
 	if err != nil {
-		return fmt.Errorf("sendcommandandwaitforresponse: receive: %w", err)
+		return err
 	}
 	for _, r := range expectedResponses {
 		if strings.EqualFold(p.CommandResponse, r) {
 			return nil
 		}
 	}
-	return fmt.Errorf("sendcommandandwaitforresponse: response (%s)", p.CommandResponse)
+	if p.CommandResponse == "" && p.ErrorResponse != "" {
+		return fmt.Errorf("unexpected error response (%s)", p.ErrorResponse)
+	}
+	return fmt.Errorf("unexpected response (%s), wanted one of %v", p.CommandResponse, expectedResponses)
 }

--- a/commands.go
+++ b/commands.go
@@ -148,42 +148,61 @@ type ComponentOptions struct {
 	SkeletonGlobal bool
 }
 
-// componentNames maps each component to the token QTM accepts on the wire.
+// componentName returns the token QTM accepts on the wire for a component, and
+// whether the component is known at all.
 //
 // ComponentType3DNoLabelsResidual previously mapped to "3dNoLabelsResidual",
-// which QTM does not recognise -- the accepted token is "3DNoLabelsRes", so
+// which QTM does not recognize -- the accepted token is "3DNoLabelsRes", so
 // requesting that component silently produced no data.
-var componentNames = map[ComponentType]string{
-	ComponentType3D:                 "3D",
-	ComponentType3DNoLabels:         "3DNoLabels",
-	ComponentTypeAnalog:             "Analog",
-	ComponentTypeForce:              "Force",
-	ComponentType6D:                 "6D",
-	ComponentType6DEuler:            "6DEuler",
-	ComponentType2D:                 "2D",
-	ComponentType2DLinearized:       "2DLin",
-	ComponentType3DResidual:         "3DRes",
-	ComponentType3DNoLabelsResidual: "3DNoLabelsRes",
-	ComponentType6DResidual:         "6DRes",
-	ComponentType6DEulerResidual:    "6DEulerRes",
-	ComponentTypeAnalogSingle:       "AnalogSingle",
-	ComponentTypeImage:              "Image",
-	ComponentTypeForceSingle:        "ForceSingle",
-	ComponentTypeGazeVector:         "GazeVector",
-	ComponentTypeTimecode:           "Timecode",
-	ComponentTypeSkeleton:           "Skeleton",
-	ComponentTypeEyeTracker:         "EyeTracker",
-}
-
-func (rt Protocol) getComponentString(c ComponentType) string {
-	return componentNames[c]
+func componentName(c ComponentType) (string, bool) {
+	switch c {
+	case ComponentType3D:
+		return "3D", true
+	case ComponentType3DNoLabels:
+		return "3DNoLabels", true
+	case ComponentTypeAnalog:
+		return "Analog", true
+	case ComponentTypeForce:
+		return "Force", true
+	case ComponentType6D:
+		return "6D", true
+	case ComponentType6DEuler:
+		return "6DEuler", true
+	case ComponentType2D:
+		return "2D", true
+	case ComponentType2DLinearized:
+		return "2DLin", true
+	case ComponentType3DResidual:
+		return "3DRes", true
+	case ComponentType3DNoLabelsResidual:
+		return "3DNoLabelsRes", true
+	case ComponentType6DResidual:
+		return "6DRes", true
+	case ComponentType6DEulerResidual:
+		return "6DEulerRes", true
+	case ComponentTypeAnalogSingle:
+		return "AnalogSingle", true
+	case ComponentTypeImage:
+		return "Image", true
+	case ComponentTypeForceSingle:
+		return "ForceSingle", true
+	case ComponentTypeGazeVector:
+		return "GazeVector", true
+	case ComponentTypeTimecode:
+		return "Timecode", true
+	case ComponentTypeSkeleton:
+		return "Skeleton", true
+	case ComponentTypeEyeTracker:
+		return "EyeTracker", true
+	}
+	return "", false
 }
 
 // componentString renders a component list with any applicable options.
 func componentString(opts ComponentOptions, components ...ComponentType) (string, error) {
 	parts := make([]string, 0, len(components))
 	for _, c := range components {
-		name, ok := componentNames[c]
+		name, ok := componentName(c)
 		if !ok {
 			return "", fmt.Errorf("unknown component type %d", int(c))
 		}
@@ -230,7 +249,12 @@ func (rt *Protocol) StreamFrames(rate StreamRateType, value int, components ...C
 }
 
 // StreamFramesWithOptions starts streaming with per-component options.
-func (rt *Protocol) StreamFramesWithOptions(rate StreamRateType, value int, opts ComponentOptions, components ...ComponentType) error {
+func (rt *Protocol) StreamFramesWithOptions(
+	rate StreamRateType,
+	value int,
+	opts ComponentOptions,
+	components ...ComponentType,
+) error {
 	return rt.streamFrames(rate, value, 0, "", opts, components...)
 }
 
@@ -240,7 +264,13 @@ func (rt *Protocol) StreamFramesWithOptions(rate StreamRateType, value int, opts
 // udpAddr may be empty, in which case QTM sends to the address the TCP
 // connection came from. Use EnableUDPStream to have the SDK open a receiving
 // socket and then read frames with ReceiveUDP.
-func (rt *Protocol) StreamFramesUDP(rate StreamRateType, value int, udpPort int, udpAddr string, opts ComponentOptions, components ...ComponentType) error {
+func (rt *Protocol) StreamFramesUDP(
+	rate StreamRateType,
+	value, udpPort int,
+	udpAddr string,
+	opts ComponentOptions,
+	components ...ComponentType,
+) error {
 	if udpPort <= 0 || udpPort > 65535 {
 		return fmt.Errorf("streamframesudp: invalid udp port %d", udpPort)
 	}
@@ -250,7 +280,13 @@ func (rt *Protocol) StreamFramesUDP(rate StreamRateType, value int, udpPort int,
 	return rt.streamFrames(rate, value, udpPort, udpAddr, opts, components...)
 }
 
-func (rt *Protocol) streamFrames(rate StreamRateType, value, udpPort int, udpAddr string, opts ComponentOptions, components ...ComponentType) error {
+func (rt *Protocol) streamFrames(
+	rate StreamRateType,
+	value, udpPort int,
+	udpAddr string,
+	opts ComponentOptions,
+	components ...ComponentType,
+) error {
 	var b strings.Builder
 	b.WriteString("StreamFrames")
 	switch rate {
@@ -328,6 +364,10 @@ func (rt *Protocol) UDPServerPort() int {
 	return 0
 }
 
+// maxUDPDatagramSize is the largest a UDP payload can be, so a single read
+// can never truncate a datagram.
+const maxUDPDatagramSize = 65536
+
 // ReceiveUDP reads one datagram from the UDP stream socket and decodes it.
 //
 // Each QTM UDP datagram carries exactly one complete packet, so unlike the TCP
@@ -341,8 +381,13 @@ func (rt *Protocol) ReceiveUDP() (*Packet, error) {
 			return &Packet{Type: PacketTypeNone}, fmt.Errorf("receiveudp: set deadline: %w", err)
 		}
 	}
-	buf := make([]byte, 65536)
-	n, _, err := rt.udpConn.ReadFromUDP(buf)
+	// Reused across calls: a fresh 64 KiB per frame is real GC pressure at
+	// streaming rates. Every decoder copies what it keeps -- see
+	// packets.cursor.Bytes -- so overwriting this on the next call is safe.
+	if rt.udpBuffer == nil {
+		rt.udpBuffer = make([]byte, maxUDPDatagramSize)
+	}
+	n, _, err := rt.udpConn.ReadFromUDP(rt.udpBuffer)
 	if err != nil {
 		if isTimeout(err) {
 			return &Packet{Type: PacketTypeNoMoreData}, nil
@@ -353,7 +398,7 @@ func (rt *Protocol) ReceiveUDP() (*Packet, error) {
 		return &Packet{Type: PacketTypeNone}, fmt.Errorf("receiveudp: datagram too short (%d bytes)", n)
 	}
 	p := &Packet{order: rt.order}
-	if err := p.UnmarshalBinary(buf[:n]); err != nil {
+	if err := p.UnmarshalBinary(rt.udpBuffer[:n]); err != nil {
 		return &Packet{Type: PacketTypeNone}, fmt.Errorf("receiveudp: unmarshal: %w", err)
 	}
 	return p, nil
@@ -499,7 +544,7 @@ func (rt *Protocol) Trig() error {
 	return nil
 }
 
-// SetQTMEvent inserts a labelled event into the current measurement.
+// SetQTMEvent inserts a labeled event into the current measurement.
 func (rt *Protocol) SetQTMEvent(label string) error {
 	// The command was renamed from "Event" in protocol version 1.8.
 	cmd := "SetQTMEvent "

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,239 @@
+package qualisys_test
+
+// Every example in the README appears here as a testable example, so `go test`
+// compiles them and they cannot drift from the API. They deliberately have no
+// "Output:" comment, which means the toolchain builds them but does not run
+// them -- none of them would work without a QTM on the network.
+//
+// They also show up in godoc alongside the functions they demonstrate, so the
+// documentation and the compiled-and-checked code are the same text.
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	qualisys "github.com/mlveggo/qualisys-go"
+	"github.com/mlveggo/qualisys-go/pkg/discover"
+)
+
+// Connect, stream every frame and print the labelled 3D markers.
+func Example() {
+	rt := qualisys.NewProtocol("192.168.0.10", qualisys.DefaultBasePort)
+	if err := rt.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer rt.Disconnect()
+
+	major, minor := rt.Version()
+	fmt.Printf("negotiated protocol %d.%d\n", major, minor)
+
+	if err := rt.StreamFramesAll(qualisys.ComponentType3D); err != nil {
+		log.Fatal(err)
+	}
+
+	for {
+		p, err := rt.Receive()
+		if err != nil {
+			log.Fatal(err)
+		}
+		// An idle socket is not an error.
+		if p.EndOfData() {
+			continue
+		}
+		if markers := p.Data.Markers3D(); markers != nil {
+			fmt.Printf("frame %d: %d markers\n", p.Data.Frame, len(markers.Markers))
+		}
+	}
+}
+
+// Find QTM instances by UDP broadcast.
+func Example_discovery() {
+	discovery := discover.NewDiscovery(4545, 1*time.Second)
+	responses, err := discovery.Discover()
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, response := range responses {
+		fmt.Println(response)
+	}
+}
+
+// Request a specific protocol version and disable the fallback ladder.
+func ExampleWithVersion() {
+	rt := qualisys.NewProtocol("192.168.0.10", qualisys.DefaultBasePort,
+		qualisys.WithVersion(1, 25),
+		qualisys.WithoutVersionNegotiation(),
+	)
+	if err := rt.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer rt.Disconnect()
+
+	major, minor := rt.Version()
+	fmt.Printf("%d.%d\n", major, minor)
+}
+
+// The settings XML root element is named after the negotiated protocol
+// version, so it must never be hard-coded.
+func ExampleProtocol_StripParametersElement() {
+	rt := qualisys.NewProtocol("192.168.0.10", qualisys.DefaultBasePort)
+	if err := rt.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer rt.Disconnect()
+
+	xml, err := rt.GetParameters(qualisys.ParameterTypeImage)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Drops <QTM_Parameters_Ver_X.Y> for whichever version was agreed on.
+	fragment := rt.StripParametersElement(xml)
+	if err := rt.SetParameters(fragment); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Restrict analog streaming to specific channels and request skeleton segments
+// in global coordinates.
+func ExampleProtocol_StreamFramesWithOptions() {
+	rt := qualisys.NewProtocol("192.168.0.10", qualisys.DefaultBasePort)
+	if err := rt.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer rt.Disconnect()
+
+	opts := qualisys.ComponentOptions{
+		AnalogChannels: "1,3,5-8", // sends "Analog:1,3,5-8"
+		SkeletonGlobal: true,      // sends "Skeleton:global"
+	}
+	if err := rt.StreamFramesWithOptions(
+		qualisys.StreamRateTypeFrequency, 100, opts,
+		qualisys.ComponentTypeAnalog, qualisys.ComponentTypeSkeleton,
+	); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Keep commands on TCP while data frames arrive over UDP.
+func ExampleProtocol_StreamFramesUDP() {
+	rt := qualisys.NewProtocol("192.168.0.10", qualisys.DefaultBasePort)
+	if err := rt.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer rt.Disconnect()
+
+	udpPort, err := rt.EnableUDPStream(0) // 0 lets the OS choose
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// An empty address means QTM replies to the TCP connection's address.
+	if err := rt.StreamFramesUDP(
+		qualisys.StreamRateTypeAllFrames, 0, udpPort, "",
+		qualisys.ComponentOptions{}, qualisys.ComponentType3D,
+	); err != nil {
+		log.Fatal(err)
+	}
+
+	for {
+		p, err := rt.ReceiveUDP()
+		if err != nil {
+			log.Fatal(err)
+		}
+		if p.EndOfData() {
+			continue
+		}
+		fmt.Println(p.Data.Frame)
+	}
+}
+
+// Timeouts, the packet size ceiling and byte order are per-connection.
+func ExampleNewProtocol_options() {
+	rt := qualisys.NewProtocol("192.168.0.10", qualisys.DefaultBasePort,
+		qualisys.WithReadTimeout(500*time.Millisecond),
+		qualisys.WithConnectTimeout(10*time.Second),
+		qualisys.WithMaxPacketSize(64<<20),
+	)
+	if err := rt.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer rt.Disconnect()
+}
+
+// Calibration takes its own timeout because it runs for minutes.
+func ExampleProtocol_Calibrate() {
+	rt := qualisys.NewProtocol("192.168.0.10", qualisys.DefaultBasePort)
+	if err := rt.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer rt.Disconnect()
+
+	if err := rt.TakeControl(""); err != nil {
+		log.Fatal(err)
+	}
+	calibrationXML, err := rt.Calibrate(false, 5*time.Minute)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(calibrationXML)
+}
+
+// A read timeout is not an error, but a truncated packet is unrecoverable.
+func ExampleProtocol_Receive_errorHandling() {
+	rt := qualisys.NewProtocol("192.168.0.10", qualisys.DefaultBasePort)
+	if err := rt.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer rt.Disconnect()
+
+	for {
+		p, err := rt.Receive()
+		switch {
+		case errors.Is(err, qualisys.ErrTruncated):
+			// Part of the packet was consumed and the rest is still queued, so
+			// the next read would misinterpret it. Nothing to do but reconnect.
+			log.Println("stream desynchronised, reconnecting")
+			return
+		case err != nil:
+			log.Fatal(err)
+		case p.EndOfData():
+			// Nothing arrived within the read timeout.
+			continue
+		}
+		fmt.Println(p.Data.Frame)
+	}
+}
+
+// Components this build cannot decode keep their raw bytes rather than failing
+// the whole frame.
+func ExampleDataPacket_UnknownComponentTypes() {
+	rt := qualisys.NewProtocol("192.168.0.10", qualisys.DefaultBasePort)
+	if err := rt.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer rt.Disconnect()
+
+	p, err := rt.Receive()
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, unknown := range p.Data.UnknownComponentTypes() {
+		fmt.Printf("QTM sent component type %d, which this build cannot decode\n", int(unknown))
+	}
+}
+
+// Download the current capture and write it to disk.
+func ExampleProtocol_SaveCaptureC3D() {
+	rt := qualisys.NewProtocol("192.168.0.10", qualisys.DefaultBasePort)
+	if err := rt.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer rt.Disconnect()
+
+	if err := rt.SaveCaptureC3D("capture.c3d"); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -7,6 +7,10 @@ package qualisys_test
 //
 // They also show up in godoc alongside the functions they demonstrate, so the
 // documentation and the compiled-and-checked code are the same text.
+//
+// Note the error handling: once Disconnect is deferred the examples log and
+// return rather than calling log.Fatal, which exits the process and would skip
+// every deferred call.
 
 import (
 	"errors"
@@ -18,7 +22,7 @@ import (
 	"github.com/mlveggo/qualisys-go/pkg/discover"
 )
 
-// Connect, stream every frame and print the labelled 3D markers.
+// Connect, stream every frame and print the labeled 3D markers.
 func Example() {
 	rt := qualisys.NewProtocol("192.168.0.10", qualisys.DefaultBasePort)
 	if err := rt.Connect(); err != nil {
@@ -30,13 +34,15 @@ func Example() {
 	fmt.Printf("negotiated protocol %d.%d\n", major, minor)
 
 	if err := rt.StreamFramesAll(qualisys.ComponentType3D); err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return
 	}
 
 	for {
 		p, err := rt.Receive()
 		if err != nil {
-			log.Fatal(err)
+			log.Println(err)
+			return
 		}
 		// An idle socket is not an error.
 		if p.EndOfData() {
@@ -86,13 +92,15 @@ func ExampleProtocol_StripParametersElement() {
 
 	xml, err := rt.GetParameters(qualisys.ParameterTypeImage)
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return
 	}
 
 	// Drops <QTM_Parameters_Ver_X.Y> for whichever version was agreed on.
 	fragment := rt.StripParametersElement(xml)
 	if err := rt.SetParameters(fragment); err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return
 	}
 }
 
@@ -113,7 +121,8 @@ func ExampleProtocol_StreamFramesWithOptions() {
 		qualisys.StreamRateTypeFrequency, 100, opts,
 		qualisys.ComponentTypeAnalog, qualisys.ComponentTypeSkeleton,
 	); err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return
 	}
 }
 
@@ -127,7 +136,8 @@ func ExampleProtocol_StreamFramesUDP() {
 
 	udpPort, err := rt.EnableUDPStream(0) // 0 lets the OS choose
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return
 	}
 
 	// An empty address means QTM replies to the TCP connection's address.
@@ -135,13 +145,15 @@ func ExampleProtocol_StreamFramesUDP() {
 		qualisys.StreamRateTypeAllFrames, 0, udpPort, "",
 		qualisys.ComponentOptions{}, qualisys.ComponentType3D,
 	); err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return
 	}
 
 	for {
 		p, err := rt.ReceiveUDP()
 		if err != nil {
-			log.Fatal(err)
+			log.Println(err)
+			return
 		}
 		if p.EndOfData() {
 			continue
@@ -172,11 +184,13 @@ func ExampleProtocol_Calibrate() {
 	defer rt.Disconnect()
 
 	if err := rt.TakeControl(""); err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return
 	}
 	calibrationXML, err := rt.Calibrate(false, 5*time.Minute)
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return
 	}
 	fmt.Println(calibrationXML)
 }
@@ -198,7 +212,8 @@ func ExampleProtocol_Receive_errorHandling() {
 			log.Println("stream desynchronised, reconnecting")
 			return
 		case err != nil:
-			log.Fatal(err)
+			log.Println(err)
+			return
 		case p.EndOfData():
 			// Nothing arrived within the read timeout.
 			continue
@@ -218,10 +233,15 @@ func ExampleDataPacket_UnknownComponentTypes() {
 
 	p, err := rt.Receive()
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return
 	}
 	for _, unknown := range p.Data.UnknownComponentTypes() {
-		fmt.Printf("QTM sent component type %d, which this build cannot decode\n", int(unknown))
+		// The payload is kept, so a caller who knows the newer format can
+		// decode it. Component would return nil here: it only hands back
+		// components this SDK decoded itself.
+		raw := p.Data.UnknownComponentData(unknown)
+		fmt.Printf("QTM sent component type %d, %d raw bytes kept\n", int(unknown), len(raw))
 	}
 }
 
@@ -234,6 +254,7 @@ func ExampleProtocol_SaveCaptureC3D() {
 	defer rt.Disconnect()
 
 	if err := rt.SaveCaptureC3D("capture.c3d"); err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return
 	}
 }

--- a/file.go
+++ b/file.go
@@ -1,6 +1,9 @@
 package qualisys
 
-import "encoding/binary"
+import (
+	"fmt"
+	"os"
+)
 
 //go:generate stringer -type FileType -trimprefix FileType
 type FileType uint32
@@ -10,16 +13,39 @@ const (
 	FileTypeQTM FileType = 8
 )
 
+// FilePacket carries a captured measurement returned by GetCaptureC3D or
+// GetCaptureQTM.
 type FilePacket struct {
+	// Size is the length of File in bytes.
 	Size uint32
+	// Type distinguishes a C3D transfer from a QTM transfer.
 	Type FileType
+	// File is the raw file content.
 	File []byte
 }
 
+// UnmarshalBinary decodes a file transfer payload.
+//
+// Two bugs are fixed here. The payload of a C3D/QTM file packet is the file
+// content itself, starting immediately after the 8 byte packet header -- the
+// previous code treated the first eight bytes of the file as a size and type
+// field and discarded them, corrupting every transfer. And File was allocated
+// with make([]byte, 0, size) before copy, so copy had zero length to write into
+// and the result was always empty.
 func (d *FilePacket) UnmarshalBinary(data []byte) error {
-	d.Size = binary.LittleEndian.Uint32(data[0:4])
-	d.Type = FileType(binary.LittleEndian.Uint32(data[4:8]))
-	d.File = make([]byte, 0, d.Size)
-	copy(d.File, data[8:])
+	d.Size = uint32(len(data))
+	d.File = make([]byte, len(data))
+	copy(d.File, data)
+	return nil
+}
+
+// WriteFile writes the transferred file to path.
+func (d *FilePacket) WriteFile(path string) error {
+	if len(d.File) == 0 {
+		return fmt.Errorf("filepacket: no file content received")
+	}
+	if err := os.WriteFile(path, d.File, 0o644); err != nil {
+		return fmt.Errorf("filepacket: write %s: %w", path, err)
+	}
 	return nil
 }

--- a/file.go
+++ b/file.go
@@ -44,7 +44,7 @@ func (d *FilePacket) WriteFile(path string) error {
 	if len(d.File) == 0 {
 		return fmt.Errorf("filepacket: no file content received")
 	}
-	if err := os.WriteFile(path, d.File, 0o644); err != nil {
+	if err := os.WriteFile(path, d.File, 0o600); err != nil {
 		return fmt.Errorf("filepacket: write %s: %w", path, err)
 	}
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,3 @@
 module github.com/mlveggo/qualisys-go
 
 go 1.23.0
-
-require gotest.tools v2.2.0+incompatible
-
-require (
-	github.com/google/go-cmp v0.5.6 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-)

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,0 @@
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
-gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/packet.go
+++ b/packet.go
@@ -53,11 +53,6 @@ type DataPacket struct {
 	Frame      uint32
 	Components []IDataObject
 
-	// Skipped lists component types present in the frame that this SDK does
-	// not know how to decode. A newer QTM may add components; recording them
-	// rather than failing keeps older clients working against newer servers.
-	Skipped []ComponentType
-
 	order binary.ByteOrder
 }
 
@@ -180,7 +175,6 @@ func (d *DataPacket) UnmarshalBinary(data []byte) error {
 	componentCount := order.Uint32(data[12:16])
 
 	d.Components = nil
-	d.Skipped = nil
 
 	pos := dataPacketHeaderSize
 	for i := uint32(0); i < componentCount; i++ {
@@ -200,17 +194,87 @@ func (d *DataPacket) UnmarshalBinary(data []byte) error {
 		}
 
 		payload := data[pos+componentHeaderSize : pos+csize]
-		if iobj := getComponentObject(ctype); iobj != nil {
-			if err := iobj.UnmarshalBinary(payload); err != nil {
-				return fmt.Errorf("datapacket: component %d (%v): %w", i, ctype, err)
-			}
-			d.Components = append(d.Components, iobj)
-		} else {
-			d.Skipped = append(d.Skipped, ctype)
+		iobj := getComponentObject(ctype)
+		if iobj == nil {
+			// Preserve the raw bytes rather than discarding them, so a caller
+			// that does understand a newer component can still decode it.
+			iobj = &UnknownComponent{Type: ctype}
 		}
+		if err := iobj.UnmarshalBinary(payload); err != nil {
+			return fmt.Errorf("datapacket: component %d (%v): %w", i, ctype, err)
+		}
+		d.Components = append(d.Components, iobj)
 		pos += csize
 	}
 	return nil
+}
+
+// UnknownComponent holds a component this SDK cannot decode.
+//
+// Newer QTM releases add components. Keeping the payload instead of failing the
+// frame means a client built against one protocol version keeps working, and
+// leaves the door open for a caller that does know the format.
+type UnknownComponent struct {
+	Type ComponentType
+	Data []byte
+}
+
+func (u *UnknownComponent) UnmarshalBinary(data []byte) error {
+	u.Data = make([]byte, len(data))
+	copy(u.Data, data)
+	return nil
+}
+
+func (u UnknownComponent) String() string {
+	return fmt.Sprintf("UnknownComponent{type: %d, %d bytes}", int(u.Type), len(u.Data))
+}
+
+// componentTypeOf reports the component type an already-decoded object came
+// from, and whether it was recognised.
+func componentTypeOf(obj IDataObject) (ComponentType, bool) {
+	switch v := obj.(type) {
+	case *packets.Component3D:
+		return ComponentType3D, true
+	case *packets.Component3DResidual:
+		return ComponentType3DResidual, true
+	case *packets.Component3DNoLabels:
+		return ComponentType3DNoLabels, true
+	case *packets.Component3DNoLabelsResidual:
+		return ComponentType3DNoLabelsResidual, true
+	case *packets.Component6D:
+		return ComponentType6D, true
+	case *packets.Component6DResidual:
+		return ComponentType6DResidual, true
+	case *packets.Component6DEuler:
+		return ComponentType6DEuler, true
+	case *packets.Component6DEulerResidual:
+		return ComponentType6DEulerResidual, true
+	case *packets.Component2D:
+		return ComponentType2D, true
+	case *packets.Component2DLinearized:
+		return ComponentType2DLinearized, true
+	case *packets.ComponentAnalog:
+		return ComponentTypeAnalog, true
+	case *packets.ComponentAnalogSingle:
+		return ComponentTypeAnalogSingle, true
+	case *packets.ComponentForce:
+		return ComponentTypeForce, true
+	case *packets.ComponentForceSingle:
+		return ComponentTypeForceSingle, true
+	case *packets.ComponentImage:
+		return ComponentTypeImage, true
+	case *packets.ComponentGazeVector:
+		return ComponentTypeGazeVector, true
+	case *packets.ComponentTimecode:
+		return ComponentTypeTimecode, true
+	case *packets.ComponentSkeleton:
+		return ComponentTypeSkeleton, true
+	case *packets.ComponentEyeTracker:
+		return ComponentTypeEyeTracker, true
+	case *UnknownComponent:
+		return v.Type, false
+	}
+	return 0, false
 }
 
 // Component returns the first decoded component of the requested type, or nil.
@@ -218,41 +282,138 @@ func (d *DataPacket) UnmarshalBinary(data []byte) error {
 // Iterating Components and type-switching works too, but this covers the common
 // case of "give me the 3D markers from this frame" without the boilerplate.
 func (d *DataPacket) Component(c ComponentType) IDataObject {
-	want := getComponentObject(c)
-	if want == nil {
-		return nil
-	}
-	wantType := fmt.Sprintf("%T", want)
 	for _, obj := range d.Components {
-		if fmt.Sprintf("%T", obj) == wantType {
+		if ctype, known := componentTypeOf(obj); known && ctype == c {
 			return obj
 		}
 	}
 	return nil
 }
 
+// UnknownComponentTypes lists component types present in the frame that this
+// SDK could not decode.
+func (d *DataPacket) UnknownComponentTypes() []ComponentType {
+	var out []ComponentType
+	for _, obj := range d.Components {
+		if u, ok := obj.(*UnknownComponent); ok {
+			out = append(out, u.Type)
+		}
+	}
+	return out
+}
+
 // Markers3D returns the labelled 3D component of the frame, if present.
 func (d *DataPacket) Markers3D() *packets.Component3D {
-	if c, ok := d.Component(ComponentType3D).(*packets.Component3D); ok {
-		return c
-	}
-	return nil
+	c, _ := d.Component(ComponentType3D).(*packets.Component3D)
+	return c
+}
+
+// Markers3DResidual returns the labelled 3D component with residuals.
+func (d *DataPacket) Markers3DResidual() *packets.Component3DResidual {
+	c, _ := d.Component(ComponentType3DResidual).(*packets.Component3DResidual)
+	return c
+}
+
+// Markers3DNoLabels returns the unlabelled 3D component.
+func (d *DataPacket) Markers3DNoLabels() *packets.Component3DNoLabels {
+	c, _ := d.Component(ComponentType3DNoLabels).(*packets.Component3DNoLabels)
+	return c
+}
+
+// Markers3DNoLabelsResidual returns the unlabelled 3D component with residuals.
+func (d *DataPacket) Markers3DNoLabelsResidual() *packets.Component3DNoLabelsResidual {
+	c, _ := d.Component(ComponentType3DNoLabelsResidual).(*packets.Component3DNoLabelsResidual)
+	return c
 }
 
 // Bodies6D returns the 6DOF matrix component of the frame, if present.
 func (d *DataPacket) Bodies6D() *packets.Component6D {
-	if c, ok := d.Component(ComponentType6D).(*packets.Component6D); ok {
-		return c
-	}
-	return nil
+	c, _ := d.Component(ComponentType6D).(*packets.Component6D)
+	return c
 }
 
-// Skeletons returns the skeleton component of the frame, if present.
+// Bodies6DResidual returns the 6DOF matrix component with residuals.
+func (d *DataPacket) Bodies6DResidual() *packets.Component6DResidual {
+	c, _ := d.Component(ComponentType6DResidual).(*packets.Component6DResidual)
+	return c
+}
+
+// Bodies6DEuler returns the 6DOF Euler component of the frame, if present.
+func (d *DataPacket) Bodies6DEuler() *packets.Component6DEuler {
+	c, _ := d.Component(ComponentType6DEuler).(*packets.Component6DEuler)
+	return c
+}
+
+// Bodies6DEulerResidual returns the 6DOF Euler component with residuals.
+func (d *DataPacket) Bodies6DEulerResidual() *packets.Component6DEulerResidual {
+	c, _ := d.Component(ComponentType6DEulerResidual).(*packets.Component6DEulerResidual)
+	return c
+}
+
+// Markers2D returns the per-camera 2D component of the frame, if present.
+func (d *DataPacket) Markers2D() *packets.Component2D {
+	c, _ := d.Component(ComponentType2D).(*packets.Component2D)
+	return c
+}
+
+// Markers2DLinearized returns the linearized per-camera 2D component.
+func (d *DataPacket) Markers2DLinearized() *packets.Component2DLinearized {
+	c, _ := d.Component(ComponentType2DLinearized).(*packets.Component2DLinearized)
+	return c
+}
+
+// Analog returns the multi-sample analog component, if present.
+func (d *DataPacket) Analog() *packets.ComponentAnalog {
+	c, _ := d.Component(ComponentTypeAnalog).(*packets.ComponentAnalog)
+	return c
+}
+
+// AnalogSingle returns the single-sample analog component, if present.
+func (d *DataPacket) AnalogSingle() *packets.ComponentAnalogSingle {
+	c, _ := d.Component(ComponentTypeAnalogSingle).(*packets.ComponentAnalogSingle)
+	return c
+}
+
+// Force returns the multi-sample force plate component, if present.
+func (d *DataPacket) Force() *packets.ComponentForce {
+	c, _ := d.Component(ComponentTypeForce).(*packets.ComponentForce)
+	return c
+}
+
+// ForceSingle returns the single-sample force plate component, if present.
+func (d *DataPacket) ForceSingle() *packets.ComponentForceSingle {
+	c, _ := d.Component(ComponentTypeForceSingle).(*packets.ComponentForceSingle)
+	return c
+}
+
+// Images returns the camera image component, if present.
+func (d *DataPacket) Images() *packets.ComponentImage {
+	c, _ := d.Component(ComponentTypeImage).(*packets.ComponentImage)
+	return c
+}
+
+// GazeVectors returns the gaze vector component, if present.
+func (d *DataPacket) GazeVectors() *packets.ComponentGazeVector {
+	c, _ := d.Component(ComponentTypeGazeVector).(*packets.ComponentGazeVector)
+	return c
+}
+
+// EyeTrackers returns the eye tracker component, if present.
+func (d *DataPacket) EyeTrackers() *packets.ComponentEyeTracker {
+	c, _ := d.Component(ComponentTypeEyeTracker).(*packets.ComponentEyeTracker)
+	return c
+}
+
+// Timecodes returns the timecode component, if present.
+func (d *DataPacket) Timecodes() *packets.ComponentTimecode {
+	c, _ := d.Component(ComponentTypeTimecode).(*packets.ComponentTimecode)
+	return c
+}
+
+// Skeletons returns the skeleton component, if present.
 func (d *DataPacket) Skeletons() *packets.ComponentSkeleton {
-	if c, ok := d.Component(ComponentTypeSkeleton).(*packets.ComponentSkeleton); ok {
-		return c
-	}
-	return nil
+	c, _ := d.Component(ComponentTypeSkeleton).(*packets.ComponentSkeleton)
+	return c
 }
 
 func trimStringResponse(data []byte) string {

--- a/packet.go
+++ b/packet.go
@@ -138,12 +138,6 @@ func getComponentObject(c ComponentType) IDataObject {
 	return nil
 }
 
-// Deprecated: use the package-level getComponentObject. Retained as a method
-// for source compatibility.
-func (d DataPacket) getComponentObject(c ComponentType) IDataObject {
-	return getComponentObject(c)
-}
-
 // dataPacketHeaderSize is timestamp (8) + frame number (4) + component count (4).
 const dataPacketHeaderSize = 16
 
@@ -157,7 +151,7 @@ const componentHeaderSize = 8
 // bounds checked, so a truncated frame is an error rather than a panic. Each
 // component parser receives exactly its own slice instead of everything to the
 // end of the buffer, so one component's parser cannot wander into the next
-// one's data. And an unrecognised component type is skipped and recorded rather
+// one's data. And an unrecognized component type is skipped and recorded rather
 // than aborting the whole frame, which is what lets a client built against one
 // protocol version keep working when QTM starts sending a component it has
 // never heard of.
@@ -230,7 +224,7 @@ func (u UnknownComponent) String() string {
 }
 
 // componentTypeOf reports the component type an already-decoded object came
-// from, and whether it was recognised.
+// from, and whether it was recognized.
 func componentTypeOf(obj IDataObject) (ComponentType, bool) {
 	switch v := obj.(type) {
 	case *packets.Component3D:
@@ -281,10 +275,30 @@ func componentTypeOf(obj IDataObject) (ComponentType, bool) {
 //
 // Iterating Components and type-switching works too, but this covers the common
 // case of "give me the 3D markers from this frame" without the boilerplate.
+//
+// Only components this SDK could decode are reachable here. A component type it
+// has never heard of is held as an UnknownComponent and is never returned by
+// this method even when its type matches; use UnknownComponentData for those.
 func (d *DataPacket) Component(c ComponentType) IDataObject {
 	for _, obj := range d.Components {
 		if ctype, known := componentTypeOf(obj); known && ctype == c {
 			return obj
+		}
+	}
+	return nil
+}
+
+// UnknownComponentData returns the raw payload of the undecodable component of
+// type c, or nil if the frame carries no such component.
+//
+// UnknownComponentTypes says which types arrived that this SDK could not
+// decode; this hands over the bytes for one of them, so a caller who does know
+// a newer component's format can decode it. Component cannot serve that role:
+// it deliberately only returns components this SDK decoded itself.
+func (d *DataPacket) UnknownComponentData(c ComponentType) []byte {
+	for _, obj := range d.Components {
+		if u, ok := obj.(*UnknownComponent); ok && u.Type == c {
+			return u.Data
 		}
 	}
 	return nil
@@ -302,25 +316,25 @@ func (d *DataPacket) UnknownComponentTypes() []ComponentType {
 	return out
 }
 
-// Markers3D returns the labelled 3D component of the frame, if present.
+// Markers3D returns the labeled 3D component of the frame, if present.
 func (d *DataPacket) Markers3D() *packets.Component3D {
 	c, _ := d.Component(ComponentType3D).(*packets.Component3D)
 	return c
 }
 
-// Markers3DResidual returns the labelled 3D component with residuals.
+// Markers3DResidual returns the labeled 3D component with residuals.
 func (d *DataPacket) Markers3DResidual() *packets.Component3DResidual {
 	c, _ := d.Component(ComponentType3DResidual).(*packets.Component3DResidual)
 	return c
 }
 
-// Markers3DNoLabels returns the unlabelled 3D component.
+// Markers3DNoLabels returns the unlabeled 3D component.
 func (d *DataPacket) Markers3DNoLabels() *packets.Component3DNoLabels {
 	c, _ := d.Component(ComponentType3DNoLabels).(*packets.Component3DNoLabels)
 	return c
 }
 
-// Markers3DNoLabelsResidual returns the unlabelled 3D component with residuals.
+// Markers3DNoLabelsResidual returns the unlabeled 3D component with residuals.
 func (d *DataPacket) Markers3DNoLabelsResidual() *packets.Component3DNoLabelsResidual {
 	c, _ := d.Component(ComponentType3DNoLabelsResidual).(*packets.Component3DNoLabelsResidual)
 	return c

--- a/packet.go
+++ b/packet.go
@@ -47,10 +47,18 @@ const (
 	PacketTypeNone
 )
 
+// DataPacket is the payload of a PacketTypeData packet.
 type DataPacket struct {
 	Timestamp  uint64
 	Frame      uint32
 	Components []IDataObject
+
+	// Skipped lists component types present in the frame that this SDK does
+	// not know how to decode. A newer QTM may add components; recording them
+	// rather than failing keeps older clients working against newer servers.
+	Skipped []ComponentType
+
+	order binary.ByteOrder
 }
 
 type Packet struct {
@@ -62,6 +70,8 @@ type Packet struct {
 	Size            int
 	Data            DataPacket
 	File            FilePacket
+
+	order binary.ByteOrder
 }
 
 func (p *Packet) Error() bool {
@@ -76,11 +86,20 @@ func (p *Packet) EndOfData() bool {
 	return p.Type == PacketTypeNoMoreData
 }
 
+// byteOrder returns the configured order, defaulting to little endian for
+// zero-valued Packets built by callers or tests.
+func (p *Packet) byteOrder() binary.ByteOrder {
+	if p.order == nil {
+		return binary.LittleEndian
+	}
+	return p.order
+}
+
 type IDataObject interface {
 	UnmarshalBinary([]byte) error
 }
 
-func (d DataPacket) getComponentObject(c ComponentType) IDataObject {
+func getComponentObject(c ComponentType) IDataObject {
 	switch c {
 	case ComponentType3D:
 		return new(packets.Component3D)
@@ -124,23 +143,114 @@ func (d DataPacket) getComponentObject(c ComponentType) IDataObject {
 	return nil
 }
 
+// Deprecated: use the package-level getComponentObject. Retained as a method
+// for source compatibility.
+func (d DataPacket) getComponentObject(c ComponentType) IDataObject {
+	return getComponentObject(c)
+}
+
+// dataPacketHeaderSize is timestamp (8) + frame number (4) + component count (4).
+const dataPacketHeaderSize = 16
+
+// componentHeaderSize is the per-component size and type fields. The size
+// field counts these 8 bytes as well as the component payload.
+const componentHeaderSize = 8
+
+// UnmarshalBinary decodes a data frame.
+//
+// Three things changed from the original implementation. Every offset is now
+// bounds checked, so a truncated frame is an error rather than a panic. Each
+// component parser receives exactly its own slice instead of everything to the
+// end of the buffer, so one component's parser cannot wander into the next
+// one's data. And an unrecognised component type is skipped and recorded rather
+// than aborting the whole frame, which is what lets a client built against one
+// protocol version keep working when QTM starts sending a component it has
+// never heard of.
 func (d *DataPacket) UnmarshalBinary(data []byte) error {
-	d.Timestamp = binary.LittleEndian.Uint64(data[0:8])
-	d.Frame = binary.LittleEndian.Uint32(data[8:12])
-	numberOfComponents := binary.LittleEndian.Uint32(data[12:16])
-	pos := uint32(16)
-	for i := uint32(0); i < numberOfComponents; i++ {
-		csize := binary.LittleEndian.Uint32(data[pos : pos+4])
-		ctype := ComponentType(binary.LittleEndian.Uint32(data[pos+4 : pos+8]))
-		iobj := d.getComponentObject(ctype)
-		if iobj == nil {
-			return fmt.Errorf("datapacket unknown data object")
+	if len(data) < dataPacketHeaderSize {
+		return fmt.Errorf("datapacket: need %d header bytes, have %d", dataPacketHeaderSize, len(data))
+	}
+	order := d.order
+	if order == nil {
+		order = binary.LittleEndian
+	}
+
+	d.Timestamp = order.Uint64(data[0:8])
+	d.Frame = order.Uint32(data[8:12])
+	componentCount := order.Uint32(data[12:16])
+
+	d.Components = nil
+	d.Skipped = nil
+
+	pos := dataPacketHeaderSize
+	for i := uint32(0); i < componentCount; i++ {
+		if pos+componentHeaderSize > len(data) {
+			return fmt.Errorf("datapacket: component %d header runs past end of packet", i)
 		}
-		if err := iobj.UnmarshalBinary(data[pos+8:]); err != nil {
-			return fmt.Errorf("datapacket unmarshalbinary: %w", err)
+		csize := int(order.Uint32(data[pos : pos+4]))
+		ctype := ComponentType(order.Uint32(data[pos+4 : pos+8]))
+
+		// A zero or undersized component length would loop forever.
+		if csize < componentHeaderSize {
+			return fmt.Errorf("datapacket: component %d has invalid size %d", i, csize)
 		}
-		d.Components = append(d.Components, iobj)
+		if pos+csize > len(data) {
+			return fmt.Errorf("datapacket: component %d claims %d bytes, only %d remain",
+				i, csize, len(data)-pos)
+		}
+
+		payload := data[pos+componentHeaderSize : pos+csize]
+		if iobj := getComponentObject(ctype); iobj != nil {
+			if err := iobj.UnmarshalBinary(payload); err != nil {
+				return fmt.Errorf("datapacket: component %d (%v): %w", i, ctype, err)
+			}
+			d.Components = append(d.Components, iobj)
+		} else {
+			d.Skipped = append(d.Skipped, ctype)
+		}
 		pos += csize
+	}
+	return nil
+}
+
+// Component returns the first decoded component of the requested type, or nil.
+//
+// Iterating Components and type-switching works too, but this covers the common
+// case of "give me the 3D markers from this frame" without the boilerplate.
+func (d *DataPacket) Component(c ComponentType) IDataObject {
+	want := getComponentObject(c)
+	if want == nil {
+		return nil
+	}
+	wantType := fmt.Sprintf("%T", want)
+	for _, obj := range d.Components {
+		if fmt.Sprintf("%T", obj) == wantType {
+			return obj
+		}
+	}
+	return nil
+}
+
+// Markers3D returns the labelled 3D component of the frame, if present.
+func (d *DataPacket) Markers3D() *packets.Component3D {
+	if c, ok := d.Component(ComponentType3D).(*packets.Component3D); ok {
+		return c
+	}
+	return nil
+}
+
+// Bodies6D returns the 6DOF matrix component of the frame, if present.
+func (d *DataPacket) Bodies6D() *packets.Component6D {
+	if c, ok := d.Component(ComponentType6D).(*packets.Component6D); ok {
+		return c
+	}
+	return nil
+}
+
+// Skeletons returns the skeleton component of the frame, if present.
+func (d *DataPacket) Skeletons() *packets.ComponentSkeleton {
+	if c, ok := d.Component(ComponentTypeSkeleton).(*packets.ComponentSkeleton); ok {
+		return c
 	}
 	return nil
 }
@@ -149,31 +259,37 @@ func trimStringResponse(data []byte) string {
 	return string(bytes.Trim(data, "\x00"))
 }
 
+// UnmarshalBinary decodes a complete packet including its 8 byte header.
 func (p *Packet) UnmarshalBinary(data []byte) error {
-	p.Size = int(binary.LittleEndian.Uint32(data[0:4]))
-	p.Type = PacketType(binary.LittleEndian.Uint32(data[4:8]))
+	if len(data) < packetHeaderSize {
+		return fmt.Errorf("packet: need %d header bytes, have %d", packetHeaderSize, len(data))
+	}
+	order := p.byteOrder()
+	p.Size = int(order.Uint32(data[0:4]))
+	p.Type = PacketType(order.Uint32(data[4:8]))
+
+	payload := data[packetHeaderSize:]
+
 	switch p.Type {
 	case PacketTypeError:
-		p.ErrorResponse = trimStringResponse(data[8:])
+		p.ErrorResponse = trimStringResponse(payload)
 	case PacketTypeCommand:
-		p.CommandResponse = trimStringResponse(data[8:])
+		p.CommandResponse = trimStringResponse(payload)
 	case PacketTypeXML:
-		p.XMLResponse = trimStringResponse(data[8:])
+		p.XMLResponse = trimStringResponse(payload)
 	case PacketTypeData:
-		return p.Data.UnmarshalBinary(data[8:])
-	case PacketTypeNoMoreData:
+		p.Data.order = order
+		return p.Data.UnmarshalBinary(payload)
+	case PacketTypeNoMoreData, PacketTypeNone, PacketTypeDiscover:
 		return nil
-	case PacketTypeNone:
-		return nil
-	case PacketTypeC3DFile:
-		return p.File.UnmarshalBinary(data[8:])
-	case PacketTypeQTMFile:
-		return p.File.UnmarshalBinary(data[8:])
+	case PacketTypeC3DFile, PacketTypeQTMFile:
+		p.File.Type = FileType(p.Type)
+		return p.File.UnmarshalBinary(payload)
 	case PacketTypeEvent:
-		p.Event = EventType(data[8])
-	case PacketTypeDiscover:
-		return nil
-	default:
+		if len(payload) < 1 {
+			return fmt.Errorf("packet: event packet has no payload")
+		}
+		p.Event = EventType(payload[0])
 	}
 	return nil
 }

--- a/packet_test.go
+++ b/packet_test.go
@@ -89,11 +89,30 @@ func TestDataPacketSkipsUnknownComponentTypes(t *testing.T) {
 	if err := d.UnmarshalBinary(payload); err != nil {
 		t.Fatalf("an unknown component should not fail the frame: %v", err)
 	}
-	if len(d.Components) != 1 {
-		t.Errorf("got %d decoded components, want 1", len(d.Components))
+	// Both components are kept: the one that decoded and the one that could not.
+	if len(d.Components) != 2 {
+		t.Errorf("got %d components, want 2", len(d.Components))
 	}
-	if len(d.Skipped) != 1 || d.Skipped[0] != futureComponent {
-		t.Errorf("Skipped = %v, want [%d]", d.Skipped, futureComponent)
+	if d.Markers3D() == nil {
+		t.Error("the recognised component should still decode")
+	}
+	unknown := d.UnknownComponentTypes()
+	if len(unknown) != 1 || unknown[0] != futureComponent {
+		t.Errorf("UnknownComponentTypes = %v, want [%d]", unknown, futureComponent)
+	}
+	// The raw bytes are preserved so a caller that does know the format can
+	// decode it themselves.
+	var raw *UnknownComponent
+	for _, c := range d.Components {
+		if u, ok := c.(*UnknownComponent); ok {
+			raw = u
+		}
+	}
+	if raw == nil {
+		t.Fatal("no UnknownComponent in the frame")
+	}
+	if string(raw.Data) != string([]byte{1, 2, 3, 4, 5, 6}) {
+		t.Errorf("preserved payload = %v, want [1 2 3 4 5 6]", raw.Data)
 	}
 }
 

--- a/packet_test.go
+++ b/packet_test.go
@@ -1,0 +1,341 @@
+package qualisys
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mlveggo/qualisys-go/pkg/packets"
+)
+
+// dataFrame builds a PacketTypeData payload (everything after the 8 byte packet
+// header) from a set of already-encoded components.
+func dataFrame(timestamp uint64, frame uint32, components ...[]byte) []byte {
+	b := make([]byte, 16)
+	binary.LittleEndian.PutUint64(b[0:8], timestamp)
+	binary.LittleEndian.PutUint32(b[8:12], frame)
+	binary.LittleEndian.PutUint32(b[12:16], uint32(len(components)))
+	for _, c := range components {
+		b = append(b, c...)
+	}
+	return b
+}
+
+// component wraps a payload in the per-component size and type header. The size
+// field counts the header itself.
+func component(t ComponentType, payload []byte) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint32(b[0:4], uint32(8+len(payload)))
+	binary.LittleEndian.PutUint32(b[4:8], uint32(t))
+	return append(b, payload...)
+}
+
+func marker3DPayload(count uint32) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint32(b[0:4], count)
+	binary.LittleEndian.PutUint16(b[4:6], 1)
+	binary.LittleEndian.PutUint16(b[6:8], 2)
+	for i := uint32(0); i < count; i++ {
+		for j := 0; j < 3; j++ {
+			b = binary.LittleEndian.AppendUint32(b, 0)
+		}
+	}
+	return b
+}
+
+func TestDataPacketDecodesMultipleComponents(t *testing.T) {
+	skeleton := make([]byte, 4) // zero skeletons
+	payload := dataFrame(1234, 42,
+		component(ComponentType3D, marker3DPayload(3)),
+		component(ComponentTypeSkeleton, skeleton),
+	)
+
+	var d DataPacket
+	if err := d.UnmarshalBinary(payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if d.Timestamp != 1234 || d.Frame != 42 {
+		t.Errorf("timestamp=%d frame=%d", d.Timestamp, d.Frame)
+	}
+	if len(d.Components) != 2 {
+		t.Fatalf("got %d components, want 2", len(d.Components))
+	}
+	m := d.Markers3D()
+	if m == nil {
+		t.Fatal("Markers3D returned nil")
+	}
+	if len(m.Markers) != 3 {
+		t.Errorf("got %d markers, want 3", len(m.Markers))
+	}
+	if d.Skeletons() == nil {
+		t.Error("Skeletons returned nil")
+	}
+}
+
+func TestDataPacketSkipsUnknownComponentTypes(t *testing.T) {
+	// Forward compatibility: a newer QTM may stream a component this SDK has
+	// never heard of. The old code returned "unknown data object" and threw the
+	// whole frame away, including the components it did understand.
+	const futureComponent ComponentType = 99
+	payload := dataFrame(1, 1,
+		component(ComponentType3D, marker3DPayload(1)),
+		component(futureComponent, []byte{1, 2, 3, 4, 5, 6}),
+	)
+
+	var d DataPacket
+	if err := d.UnmarshalBinary(payload); err != nil {
+		t.Fatalf("an unknown component should not fail the frame: %v", err)
+	}
+	if len(d.Components) != 1 {
+		t.Errorf("got %d decoded components, want 1", len(d.Components))
+	}
+	if len(d.Skipped) != 1 || d.Skipped[0] != futureComponent {
+		t.Errorf("Skipped = %v, want [%d]", d.Skipped, futureComponent)
+	}
+}
+
+func TestDataPacketRejectsZeroLengthComponent(t *testing.T) {
+	// A zero size field would advance the cursor by nothing and loop forever.
+	payload := dataFrame(1, 1)
+	bad := make([]byte, 8)
+	binary.LittleEndian.PutUint32(bad[0:4], 0)
+	binary.LittleEndian.PutUint32(bad[4:8], uint32(ComponentType3D))
+	binary.LittleEndian.PutUint32(payload[12:16], 1)
+	payload = append(payload, bad...)
+
+	var d DataPacket
+	if err := d.UnmarshalBinary(payload); err == nil {
+		t.Fatal("expected an error for a zero-length component")
+	}
+}
+
+func TestDataPacketRejectsComponentRunningPastEnd(t *testing.T) {
+	payload := dataFrame(1, 1)
+	bad := make([]byte, 8)
+	binary.LittleEndian.PutUint32(bad[0:4], 4096) // far beyond what follows
+	binary.LittleEndian.PutUint32(bad[4:8], uint32(ComponentType3D))
+	binary.LittleEndian.PutUint32(payload[12:16], 1)
+	payload = append(payload, bad...)
+
+	var d DataPacket
+	if err := d.UnmarshalBinary(payload); err == nil {
+		t.Fatal("expected an error for a component claiming more bytes than remain")
+	}
+}
+
+func TestDataPacketComponentsAreBoundedToTheirOwnSlice(t *testing.T) {
+	// Each parser must see only its own payload. Passing everything to the end
+	// of the buffer, as the old code did, let one component's parser read into
+	// the next component's bytes when a count field was wrong.
+	first := marker3DPayload(1)
+	binary.LittleEndian.PutUint32(first[0:4], 5) // claims 5 markers, carries 1
+
+	payload := dataFrame(1, 1,
+		component(ComponentType3D, first),
+		component(ComponentType6D, make([]byte, 200)),
+	)
+
+	var d DataPacket
+	if err := d.UnmarshalBinary(payload); err == nil {
+		t.Fatal("expected the over-claiming component to fail rather than read into its neighbour")
+	}
+}
+
+func TestPacketUnmarshalEventRequiresPayload(t *testing.T) {
+	b := make([]byte, packetHeaderSize)
+	binary.LittleEndian.PutUint32(b[0:4], packetHeaderSize)
+	binary.LittleEndian.PutUint32(b[4:8], uint32(PacketTypeEvent))
+
+	var p Packet
+	if err := p.UnmarshalBinary(b); err == nil {
+		t.Error("expected an error for an event packet with no payload")
+	}
+}
+
+func TestFilePacketKeepsEveryByte(t *testing.T) {
+	// The payload of a C3D or QTM file packet is the file content itself. The
+	// old decoder consumed the first 8 bytes as a size and type field and then
+	// copied into a zero-length slice, so transfers came back empty and
+	// truncated at once.
+	content := []byte("C3D\x00\x01\x02\x03\x04rest of the capture")
+
+	var f FilePacket
+	if err := f.UnmarshalBinary(content); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if int(f.Size) != len(content) {
+		t.Errorf("Size = %d, want %d", f.Size, len(content))
+	}
+	if string(f.File) != string(content) {
+		t.Errorf("File = %q, want %q", f.File, content)
+	}
+}
+
+func TestFilePacketWriteFile(t *testing.T) {
+	f := FilePacket{File: []byte("payload"), Size: 7}
+	path := filepath.Join(t.TempDir(), "capture.c3d")
+	if err := f.WriteFile(path); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Errorf("got %q", got)
+	}
+
+	empty := FilePacket{}
+	if err := empty.WriteFile(path); err == nil {
+		t.Error("expected writing an empty transfer to fail loudly")
+	}
+}
+
+func TestComponentStringNames(t *testing.T) {
+	// ComponentType3DNoLabelsResidual previously rendered as
+	// "3dNoLabelsResidual", which QTM does not accept, so that component
+	// silently never streamed.
+	got, err := componentString(ComponentOptions{},
+		ComponentType3D, ComponentType3DNoLabelsResidual, ComponentType6DEulerResidual)
+	if err != nil {
+		t.Fatalf("componentString: %v", err)
+	}
+	want := "3D 3DNoLabelsRes 6DEulerRes"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestComponentStringOptions(t *testing.T) {
+	got, err := componentString(
+		ComponentOptions{AnalogChannels: "1,3,5-8", SkeletonGlobal: true},
+		ComponentTypeAnalog, ComponentTypeAnalogSingle, ComponentTypeSkeleton, ComponentType3D)
+	if err != nil {
+		t.Fatalf("componentString: %v", err)
+	}
+	want := "Analog:1,3,5-8 AnalogSingle:1,3,5-8 Skeleton:global 3D"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestComponentStringRejectsUnknownComponent(t *testing.T) {
+	if _, err := componentString(ComponentOptions{}, ComponentType(123)); err == nil {
+		t.Error("expected an error for an unknown component type")
+	}
+}
+
+func TestStreamFramesCommandFormatting(t *testing.T) {
+	f := newFakeQTM(t)
+	f.handler = func(cmd string) []byte {
+		if strings.HasPrefix(cmd, "Version ") {
+			return commandPacket("Version set to 1.28")
+		}
+		if cmd == "GetState" {
+			return eventPacket(EventTypeConnected)
+		}
+		return nil
+	}
+	f.start()
+
+	rt := NewProtocol("127.0.0.1", f.basePort())
+	if err := rt.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer rt.Disconnect()
+
+	if err := rt.StreamFrames(StreamRateTypeFrequency, 100, ComponentType3D); err != nil {
+		t.Fatalf("streamframes: %v", err)
+	}
+	if err := rt.StreamFramesUDP(StreamRateTypeAllFrames, 0, 6734, "192.168.0.5",
+		ComponentOptions{SkeletonGlobal: true}, ComponentTypeSkeleton); err != nil {
+		t.Fatalf("streamframesudp: %v", err)
+	}
+
+	want := []string{
+		"StreamFrames Frequency:100 3D",
+		"StreamFrames AllFrames UDP:192.168.0.5:6734 Skeleton:global",
+	}
+	for _, w := range want {
+		if !f.waitForCommand(w, 2*time.Second) {
+			t.Errorf("missing command %q in %v", w, f.sentCommands())
+		}
+	}
+}
+
+func TestStreamFramesRequiresComponents(t *testing.T) {
+	rt := NewProtocol("127.0.0.1", 22222)
+	if err := rt.StreamFrames(StreamRateTypeAllFrames, 0); err == nil {
+		t.Error("expected an error when no components are requested")
+	}
+}
+
+func TestStreamFramesUDPValidatesPort(t *testing.T) {
+	rt := NewProtocol("127.0.0.1", 22222)
+	if err := rt.StreamFramesUDP(StreamRateTypeAllFrames, 0, 0, "", ComponentOptions{}, ComponentType3D); err == nil {
+		t.Error("expected an error for UDP port 0")
+	}
+	if err := rt.StreamFramesUDP(StreamRateTypeAllFrames, 0, 70000, "", ComponentOptions{}, ComponentType3D); err == nil {
+		t.Error("expected an error for an out-of-range UDP port")
+	}
+}
+
+func TestEnableUDPStreamAllocatesPort(t *testing.T) {
+	rt := NewProtocol("127.0.0.1", 22222)
+	port, err := rt.EnableUDPStream(0)
+	if err != nil {
+		t.Fatalf("enableudpstream: %v", err)
+	}
+	defer rt.Disconnect()
+	if port == 0 {
+		t.Fatal("expected a concrete port to be allocated")
+	}
+	if rt.UDPServerPort() != port {
+		t.Errorf("UDPServerPort = %d, want %d", rt.UDPServerPort(), port)
+	}
+}
+
+func TestReceiveUDPDecodesDatagram(t *testing.T) {
+	rt := NewProtocol("127.0.0.1", 22222, WithReadTimeout(2*time.Second))
+	port, err := rt.EnableUDPStream(0)
+	if err != nil {
+		t.Fatalf("enableudpstream: %v", err)
+	}
+	defer rt.Disconnect()
+
+	frame := dataFrame(7, 8, component(ComponentType3D, marker3DPayload(2)))
+	pkt := encodePacket(PacketTypeData, frame)
+
+	conn, err := netDialUDP(port)
+	if err != nil {
+		t.Fatalf("dial udp: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write(pkt); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	p, err := rt.ReceiveUDP()
+	if err != nil {
+		t.Fatalf("receiveudp: %v", err)
+	}
+	if !p.IsPacketData() {
+		t.Fatalf("got packet type %v", p.Type)
+	}
+	if p.Data.Frame != 8 {
+		t.Errorf("frame = %d, want 8", p.Data.Frame)
+	}
+	m, ok := p.Data.Component(ComponentType3D).(*packets.Component3D)
+	if !ok || len(m.Markers) != 2 {
+		t.Errorf("3D component = %v", p.Data.Component(ComponentType3D))
+	}
+}
+
+// netDialUDP is a small helper kept separate to avoid importing net into the
+// main body of this file's imports twice.
+func netDialUDP(port int) (netConn, error) {
+	return dialUDPLoopback(port)
+}

--- a/packet_test.go
+++ b/packet_test.go
@@ -14,10 +14,10 @@ import (
 // dataFrame builds a PacketTypeData payload (everything after the 8 byte packet
 // header) from a set of already-encoded components.
 func dataFrame(timestamp uint64, frame uint32, components ...[]byte) []byte {
-	b := make([]byte, 16)
-	binary.LittleEndian.PutUint64(b[0:8], timestamp)
-	binary.LittleEndian.PutUint32(b[8:12], frame)
-	binary.LittleEndian.PutUint32(b[12:16], uint32(len(components)))
+	b := make([]byte, 0, dataPacketHeaderSize)
+	b = binary.LittleEndian.AppendUint64(b, timestamp)
+	b = binary.LittleEndian.AppendUint32(b, frame)
+	b = binary.LittleEndian.AppendUint32(b, uint32(len(components)))
 	for _, c := range components {
 		b = append(b, c...)
 	}
@@ -27,9 +27,9 @@ func dataFrame(timestamp uint64, frame uint32, components ...[]byte) []byte {
 // component wraps a payload in the per-component size and type header. The size
 // field counts the header itself.
 func component(t ComponentType, payload []byte) []byte {
-	b := make([]byte, 8)
-	binary.LittleEndian.PutUint32(b[0:4], uint32(8+len(payload)))
-	binary.LittleEndian.PutUint32(b[4:8], uint32(t))
+	b := make([]byte, 0, componentHeaderSize+len(payload))
+	b = binary.LittleEndian.AppendUint32(b, uint32(componentHeaderSize+len(payload)))
+	b = binary.LittleEndian.AppendUint32(b, uint32(t))
 	return append(b, payload...)
 }
 
@@ -94,7 +94,7 @@ func TestDataPacketSkipsUnknownComponentTypes(t *testing.T) {
 		t.Errorf("got %d components, want 2", len(d.Components))
 	}
 	if d.Markers3D() == nil {
-		t.Error("the recognised component should still decode")
+		t.Error("the recognized component should still decode")
 	}
 	unknown := d.UnknownComponentTypes()
 	if len(unknown) != 1 || unknown[0] != futureComponent {
@@ -102,17 +102,21 @@ func TestDataPacketSkipsUnknownComponentTypes(t *testing.T) {
 	}
 	// The raw bytes are preserved so a caller that does know the format can
 	// decode it themselves.
-	var raw *UnknownComponent
-	for _, c := range d.Components {
-		if u, ok := c.(*UnknownComponent); ok {
-			raw = u
-		}
-	}
+	raw := d.UnknownComponentData(futureComponent)
 	if raw == nil {
 		t.Fatal("no UnknownComponent in the frame")
 	}
-	if string(raw.Data) != string([]byte{1, 2, 3, 4, 5, 6}) {
-		t.Errorf("preserved payload = %v, want [1 2 3 4 5 6]", raw.Data)
+	if string(raw) != string([]byte{1, 2, 3, 4, 5, 6}) {
+		t.Errorf("preserved payload = %v, want [1 2 3 4 5 6]", raw)
+	}
+	// Component deliberately surfaces only components this SDK decoded itself,
+	// so an undecodable type stays out of it however its type is spelled.
+	// UnknownComponentData is the way to those bytes.
+	if obj := d.Component(futureComponent); obj != nil {
+		t.Errorf("Component(%d) = %v, want nil for an undecodable type", futureComponent, obj)
+	}
+	if d.UnknownComponentData(ComponentType3D) != nil {
+		t.Error("UnknownComponentData returned bytes for a type that decoded fine")
 	}
 }
 
@@ -159,7 +163,7 @@ func TestDataPacketComponentsAreBoundedToTheirOwnSlice(t *testing.T) {
 
 	var d DataPacket
 	if err := d.UnmarshalBinary(payload); err == nil {
-		t.Fatal("expected the over-claiming component to fail rather than read into its neighbour")
+		t.Fatal("expected the over-claiming component to fail rather than read into its neighbor")
 	}
 }
 

--- a/parameters.go
+++ b/parameters.go
@@ -2,6 +2,8 @@ package qualisys
 
 import (
 	"fmt"
+	"strings"
+	"time"
 )
 
 //go:generate stringer -type ParameterType -trimprefix ParameterType
@@ -21,43 +23,98 @@ const (
 	ParameterTypeSkeleton
 )
 
-// GetParameters fetches xml settings from QTM for specified.
-func (rt *Protocol) GetParameters(parameters ...ParameterType) (string, error) {
-	parametersToString := map[ParameterType]string{
-		ParameterTypeAll:         "All",
-		ParameterTypeGeneral:     "General",
-		ParameterTypeCalibration: "Calibration",
-		ParameterType3D:          "3D",
-		ParameterType6D:          "6D",
-		ParameterTypeAnalog:      "Analog",
-		ParameterTypeForce:       "Force",
-		ParameterTypeImage:       "Image",
-		ParameterTypeGazeVector:  "GazeVector",
-		ParameterTypeEyeTracker:  "EyeTracker",
-		ParameterTypeSkeleton:    "Skeleton",
-	}
-	if !rt.IsConnected() {
-		return "", fmt.Errorf("getparameters: not connected")
-	}
-	cmd := "GetParameters"
-	for _, p := range parameters {
-		cmd += " " + parametersToString[p]
-	}
-	if err := rt.sendCommand(cmd); err != nil {
-		return "", fmt.Errorf("getparameters sendcmd: %w", err)
-	}
-	p, err := rt.Receive()
-	if err != nil {
-		return "", fmt.Errorf("getparameters receive: %w", err)
-	}
-	return p.XMLResponse, nil
+var parameterNames = map[ParameterType]string{
+	ParameterTypeAll:         "All",
+	ParameterTypeGeneral:     "General",
+	ParameterTypeCalibration: "Calibration",
+	ParameterType3D:          "3D",
+	ParameterType6D:          "6D",
+	ParameterTypeAnalog:      "Analog",
+	ParameterTypeForce:       "Force",
+	ParameterTypeImage:       "Image",
+	ParameterTypeGazeVector:  "GazeVector",
+	ParameterTypeEyeTracker:  "EyeTracker",
+	ParameterTypeSkeleton:    "Skeleton",
 }
 
+// ParameterOptions carries modifiers accepted after a parameter name.
+type ParameterOptions struct {
+	// SkeletonGlobal requests skeleton definitions with global rather than
+	// parent-relative segment transforms ("Skeleton:global").
+	SkeletonGlobal bool
+}
+
+// GetParameters fetches settings XML from QTM for the requested sections.
+func (rt *Protocol) GetParameters(parameters ...ParameterType) (string, error) {
+	return rt.GetParametersWithOptions(ParameterOptions{}, parameters...)
+}
+
+// GetParametersWithOptions fetches settings XML with parameter modifiers.
+//
+// Unlike the previous implementation this skips event packets while waiting.
+// QTM emits events asynchronously, so an event arriving between the request and
+// the reply used to make GetParameters return an empty string with no error.
+func (rt *Protocol) GetParametersWithOptions(opts ParameterOptions, parameters ...ParameterType) (string, error) {
+	if !rt.IsConnected() {
+		return "", fmt.Errorf("getparameters: %w", ErrNotConnected)
+	}
+	if len(parameters) == 0 {
+		parameters = []ParameterType{ParameterTypeAll}
+	}
+
+	names := make([]string, 0, len(parameters))
+	for _, p := range parameters {
+		name, ok := parameterNames[p]
+		if !ok {
+			return "", fmt.Errorf("getparameters: unknown parameter type %d", int(p))
+		}
+		if p == ParameterTypeSkeleton && opts.SkeletonGlobal {
+			name += ":global"
+		}
+		names = append(names, name)
+	}
+
+	cmd := "GetParameters " + strings.Join(names, " ")
+	if err := rt.sendCommand(cmd); err != nil {
+		return "", fmt.Errorf("getparameters: %w", err)
+	}
+
+	deadline := time.Now().Add(DefaultCommandTimeout)
+	for time.Now().Before(deadline) {
+		p, err := rt.ReceiveTimeout(time.Until(deadline))
+		if err != nil {
+			return "", fmt.Errorf("getparameters: %w", err)
+		}
+		switch p.Type {
+		case PacketTypeXML:
+			return p.XMLResponse, nil
+		case PacketTypeError:
+			return "", fmt.Errorf("getparameters: %s", p.ErrorResponse)
+		}
+	}
+	return "", fmt.Errorf("getparameters: %w waiting for XML response", ErrTimeout)
+}
+
+// SetParameters sends a settings XML fragment. The fragment is wrapped in
+// <QTM_Settings> for the caller.
 func (rt *Protocol) SetParameters(xml string) error {
 	s := "<QTM_Settings>" + xml + "</QTM_Settings>"
 	qtmResponses := []string{"Setting parameters succeeded"}
 	if err := rt.sendAndWaitForResponse(rt.sendXML, s, qtmResponses); err != nil {
-		return fmt.Errorf("setparameters sendcmd: %w", err)
+		return fmt.Errorf("setparameters: %w", err)
 	}
 	return nil
+}
+
+// StripParametersElement removes the version-specific QTM_Parameters_Ver_X.Y
+// wrapper from a GetParameters response, leaving the inner fragment ready to
+// pass to SetParameters.
+//
+// Callers used to hard-code the element name, which broke the moment the
+// negotiated protocol version changed.
+func (rt *Protocol) StripParametersElement(xml string) string {
+	name := rt.ParametersElementName()
+	xml = strings.Replace(xml, "<"+name+">", "", 1)
+	xml = strings.Replace(xml, "</"+name+">", "", 1)
+	return strings.TrimSpace(xml)
 }

--- a/parameters.go
+++ b/parameters.go
@@ -23,18 +23,34 @@ const (
 	ParameterTypeSkeleton
 )
 
-var parameterNames = map[ParameterType]string{
-	ParameterTypeAll:         "All",
-	ParameterTypeGeneral:     "General",
-	ParameterTypeCalibration: "Calibration",
-	ParameterType3D:          "3D",
-	ParameterType6D:          "6D",
-	ParameterTypeAnalog:      "Analog",
-	ParameterTypeForce:       "Force",
-	ParameterTypeImage:       "Image",
-	ParameterTypeGazeVector:  "GazeVector",
-	ParameterTypeEyeTracker:  "EyeTracker",
-	ParameterTypeSkeleton:    "Skeleton",
+// parameterName returns the token QTM accepts for a settings section, and
+// whether the section is known at all.
+func parameterName(p ParameterType) (string, bool) {
+	switch p {
+	case ParameterTypeAll:
+		return "All", true
+	case ParameterTypeGeneral:
+		return "General", true
+	case ParameterTypeCalibration:
+		return "Calibration", true
+	case ParameterType3D:
+		return "3D", true
+	case ParameterType6D:
+		return "6D", true
+	case ParameterTypeAnalog:
+		return "Analog", true
+	case ParameterTypeForce:
+		return "Force", true
+	case ParameterTypeImage:
+		return "Image", true
+	case ParameterTypeGazeVector:
+		return "GazeVector", true
+	case ParameterTypeEyeTracker:
+		return "EyeTracker", true
+	case ParameterTypeSkeleton:
+		return "Skeleton", true
+	}
+	return "", false
 }
 
 // ParameterOptions carries modifiers accepted after a parameter name.
@@ -64,7 +80,7 @@ func (rt *Protocol) GetParametersWithOptions(opts ParameterOptions, parameters .
 
 	names := make([]string, 0, len(parameters))
 	for _, p := range parameters {
-		name, ok := parameterNames[p]
+		name, ok := parameterName(p)
 		if !ok {
 			return "", fmt.Errorf("getparameters: unknown parameter type %d", int(p))
 		}

--- a/pkg/discover/discover.go
+++ b/pkg/discover/discover.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"slices"
 	"strconv"
@@ -107,6 +106,16 @@ func (dr *Response) String() string {
 type Discovery struct {
 	receivePort uint16
 	timeout     time.Duration
+
+	// OnMalformedResponse, if set, is called for every reply that could not be
+	// decoded, with the address it arrived from. Discovery continues either
+	// way: one bad reply must not hide every other QTM on the network. Leaving
+	// it nil skips those replies silently.
+	//
+	// This exists because writing to the global logger from a library is a
+	// side effect the caller can neither redirect nor switch off. Whether a
+	// malformed reply is worth reporting, and where, belongs to the caller.
+	OnMalformedResponse func(addr string, err error)
 }
 
 func NewDiscovery(receivePort uint16, timeout time.Duration) *Discovery {
@@ -168,7 +177,9 @@ func (d *Discovery) Discover() ([]Response, error) {
 		if err := dr.UnmarshalBinary(b[0:size]); err != nil {
 			// A malformed reply from one host should not abort discovery of
 			// the rest of the network.
-			log.Printf("discover: ignoring response from %s: %v", host, err)
+			if d.OnMalformedResponse != nil {
+				d.OnMalformedResponse(host, err)
+			}
 			continue
 		}
 		if !slices.Contains(responses, dr) {

--- a/pkg/discover/discover.go
+++ b/pkg/discover/discover.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -93,12 +95,12 @@ type Response struct {
 
 func (dr *Response) String() string {
 	return fmt.Sprintf(
-		"IP: %s\nHost: %s\nQTM Version: %s\nNumner of cameras: %d\nBase port: %d\n",
-		dr.Address,
+		"%s (%s) at %s:%d with %d cameras",
 		dr.Hostname,
 		dr.QtmVersion,
-		dr.Cameras,
+		dr.Address,
 		dr.BasePort,
+		dr.Cameras,
 	)
 }
 
@@ -158,12 +160,20 @@ func (d *Discovery) Discover() ([]Response, error) {
 			}
 			return nil, fmt.Errorf("discover: readfrom: %w", err)
 		}
-		ipAndPort := strings.Split(addr.String(), ":")
-		dr := Response{Address: ipAndPort[0]}
-		if err := dr.UnmarshalBinary(b[0:size]); err != nil {
-			return nil, fmt.Errorf("discover: unmarshal: %w", err)
+		host, _, splitErr := net.SplitHostPort(addr.String())
+		if splitErr != nil {
+			host = addr.String()
 		}
-		responses = append(responses, dr)
+		dr := Response{Address: host}
+		if err := dr.UnmarshalBinary(b[0:size]); err != nil {
+			// A malformed reply from one host should not abort discovery of
+			// the rest of the network.
+			log.Printf("discover: ignoring response from %s: %v", host, err)
+			continue
+		}
+		if !slices.Contains(responses, dr) {
+			responses = append(responses, dr)
+		}
 	}
 	return responses, nil
 }

--- a/pkg/discover/discover_test.go
+++ b/pkg/discover/discover_test.go
@@ -2,29 +2,61 @@ package discover_test
 
 import (
 	"encoding/binary"
+	"strings"
 	"testing"
 
 	"github.com/mlveggo/qualisys-go/pkg/discover"
-	"gotest.tools/assert"
 )
 
-func Test_UnmarshalBinaryEmptyBuffer(t *testing.T) {
+// These tests use only the standard library. The previous version depended on
+// gotest.tools, an unmaintained v2 module pulled in solely for three assertion
+// helpers; dropping it means `go test ./...` works without any module fetch.
+
+func TestUnmarshalBinaryRejectsShortBuffer(t *testing.T) {
 	var dr discover.Response
-	b := make([]byte, 10)
-	err := dr.UnmarshalBinary(b)
-	assert.ErrorContains(t, err, "too little data to UnmarshalBinary from")
+	err := dr.UnmarshalBinary(make([]byte, 10))
+	if err == nil {
+		t.Fatal("expected an error for a buffer below the minimum length")
+	}
+	if !strings.Contains(err.Error(), "too little data") {
+		t.Errorf("got %v", err)
+	}
 }
 
-func Test_UnmarshalBinaryGoodBuffer(t *testing.T) {
+func TestUnmarshalBinaryParsesResponse(t *testing.T) {
 	b := make([]byte, 60)
 	binary.LittleEndian.PutUint32(b, 60)
 	binary.LittleEndian.PutUint32(b[4:8], 1)
 	copy(b[8:48], "TestHost, QTM 2025.1 32300, 1234 cameras  ")
 	binary.BigEndian.PutUint16(b[58:60], 22226)
+
 	var dr discover.Response
-	err := dr.UnmarshalBinary(b)
-	assert.Assert(t, err == nil)
-	assert.Equal(t, dr.Cameras, 1234)
-	assert.Equal(t, dr.QtmVersion, "QTM 2025.1 32300")
-	assert.Equal(t, dr.Hostname, "TestHost")
+	if err := dr.UnmarshalBinary(b); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if dr.Hostname != "TestHost" {
+		t.Errorf("hostname = %q, want TestHost", dr.Hostname)
+	}
+	if dr.QtmVersion != "QTM 2025.1 32300" {
+		t.Errorf("version = %q", dr.QtmVersion)
+	}
+	if dr.Cameras != 1234 {
+		t.Errorf("cameras = %d, want 1234", dr.Cameras)
+	}
+	if dr.BasePort != 22226 {
+		t.Errorf("baseport = %d, want 22226", dr.BasePort)
+	}
+}
+
+func TestUnmarshalBinaryRejectsMalformedInfo(t *testing.T) {
+	b := make([]byte, 60)
+	binary.LittleEndian.PutUint32(b, 60)
+	binary.LittleEndian.PutUint32(b[4:8], 1)
+	copy(b[8:48], "no commas here at all")
+	binary.BigEndian.PutUint16(b[58:60], 22226)
+
+	var dr discover.Response
+	if err := dr.UnmarshalBinary(b); err == nil {
+		t.Error("expected an error for a malformed information field")
+	}
 }

--- a/pkg/packets/analog.go
+++ b/pkg/packets/analog.go
@@ -1,30 +1,18 @@
 package packets
 
-import (
-	"encoding/binary"
-	"fmt"
-	"math"
-)
-
-func Float32frombytes(bytes []byte) float32 {
-	return math.Float32frombits(binary.LittleEndian.Uint32(bytes))
-}
+import "fmt"
 
 type AnalogSample struct {
 	Value float32
 }
 
-func (as AnalogSample) String() string {
-	return fmt.Sprintf("[%v]", as.Value)
-}
+func (as AnalogSample) String() string { return fmt.Sprintf("[%v]", as.Value) }
 
 type AnalogChannel struct {
 	Samples []AnalogSample
 }
 
-func (ac AnalogChannel) String() string {
-	return fmt.Sprintf("[Ch: %v]", ac.Samples)
-}
+func (ac AnalogChannel) String() string { return fmt.Sprintf("[Ch: %v]", ac.Samples) }
 
 type AnalogDevice struct {
 	ID           uint32
@@ -43,62 +31,82 @@ type ComponentAnalog struct {
 func (c ComponentAnalog) String() string {
 	var s string
 	for _, ad := range c.AnalogDevices {
-		s += fmt.Sprintf("%v", ad.String())
+		s += ad.String()
 	}
 	return s
 }
 
+// UnmarshalBinary decodes the multi-sample analog component.
+//
+// Layout per device: deviceID, channel count, sample count, sample number, then
+// sampleCount samples for channel 0, then sampleCount samples for channel 1,
+// and so on. Note the samples are grouped by channel, not interleaved.
 func (c *ComponentAnalog) UnmarshalBinary(data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
-	numberOfAnalogDevices := binary.LittleEndian.Uint32(data[0:4])
-	pos := 4
-	c.AnalogDevices = make([]AnalogDevice, 0, numberOfAnalogDevices)
-	for m := uint32(0); m < numberOfAnalogDevices; m++ {
-		fp := AnalogDevice{}
-		fp.ID = binary.LittleEndian.Uint32(data[pos : pos+4])
-		channels := binary.LittleEndian.Uint32(data[pos+4 : pos+8])
-		samples := binary.LittleEndian.Uint32(data[pos+8 : pos+12])
-		fp.SampleNumber = binary.LittleEndian.Uint32(data[pos+12 : pos+16])
-		fp.Channels = make([]AnalogChannel, channels)
-		for ch := uint32(0); ch < channels; ch++ {
-			if samples > 0 {
-				fp.Channels[ch].Samples = make([]AnalogSample, samples)
-				for i := uint32(0); i < samples; i++ {
-					fp.Channels[ch].Samples[i].Value = Float32frombytes(data[pos+16 : pos+20])
-					pos += 4
-				}
+	cur := newCursor(data)
+	deviceCount := cur.Uint32()
+	if !cur.checkCount(deviceCount, 16, "analog device") {
+		return cur.Err()
+	}
+
+	c.AnalogDevices = make([]AnalogDevice, 0, deviceCount)
+	for i := uint32(0); i < deviceCount; i++ {
+		dev := AnalogDevice{ID: cur.Uint32()}
+		channelCount := cur.Uint32()
+		sampleCount := cur.Uint32()
+		dev.SampleNumber = cur.Uint32()
+
+		if cur.err == nil && uint64(channelCount)*uint64(sampleCount)*4 > uint64(cur.Remaining()) {
+			cur.fail(fmt.Errorf("%w: analog device %d claims %d channels x %d samples",
+				ErrShortPacket, dev.ID, channelCount, sampleCount))
+			return cur.Err()
+		}
+
+		dev.Channels = make([]AnalogChannel, channelCount)
+		for ch := uint32(0); ch < channelCount; ch++ {
+			if sampleCount == 0 {
+				continue
+			}
+			dev.Channels[ch].Samples = make([]AnalogSample, sampleCount)
+			for s := uint32(0); s < sampleCount; s++ {
+				dev.Channels[ch].Samples[s].Value = cur.Float32()
 			}
 		}
-		c.AnalogDevices = append(c.AnalogDevices, fp)
-		pos += 16
+		c.AnalogDevices = append(c.AnalogDevices, dev)
 	}
-	return nil
+	return cur.Err()
 }
 
 type ComponentAnalogSingle ComponentAnalog
 
-func (c ComponentAnalogSingle) String() string {
-	return ComponentAnalog(c).String()
-}
+func (c ComponentAnalogSingle) String() string { return ComponentAnalog(c).String() }
 
+// UnmarshalBinary decodes the single-sample analog component: one value per
+// channel, no sample count or sample number field.
 func (c *ComponentAnalogSingle) UnmarshalBinary(data []byte) error {
-	numberOfAnalogDevices := binary.LittleEndian.Uint32(data[0:4])
-	pos := 4
-	c.AnalogDevices = make([]AnalogDevice, 0, numberOfAnalogDevices)
-	for m := uint32(0); m < numberOfAnalogDevices; m++ {
-		fp := AnalogDevice{}
-		fp.ID = binary.LittleEndian.Uint32(data[pos : pos+4])
-		channels := binary.LittleEndian.Uint32(data[pos+4 : pos+8])
-		fp.Channels = make([]AnalogChannel, channels)
-		for ch := uint32(0); ch < channels; ch++ {
-			fp.Channels[ch].Samples = make([]AnalogSample, 1)
-			fp.Channels[ch].Samples[0].Value = Float32frombytes(data[pos+8 : pos+12])
-			pos += 4
-		}
-		c.AnalogDevices = append(c.AnalogDevices, fp)
-		pos += 8
+	if len(data) == 0 {
+		return nil
 	}
-	return nil
+	cur := newCursor(data)
+	deviceCount := cur.Uint32()
+	if !cur.checkCount(deviceCount, 8, "analog device") {
+		return cur.Err()
+	}
+
+	c.AnalogDevices = make([]AnalogDevice, 0, deviceCount)
+	for i := uint32(0); i < deviceCount; i++ {
+		dev := AnalogDevice{ID: cur.Uint32()}
+		channelCount := cur.Uint32()
+		if !cur.checkCount(channelCount, 4, "analog channel") {
+			return cur.Err()
+		}
+		dev.Channels = make([]AnalogChannel, channelCount)
+		for ch := uint32(0); ch < channelCount; ch++ {
+			dev.Channels[ch].Samples = []AnalogSample{{Value: cur.Float32()}}
+		}
+		c.AnalogDevices = append(c.AnalogDevices, dev)
+	}
+	return cur.Err()
 }

--- a/pkg/packets/cursor.go
+++ b/pkg/packets/cursor.go
@@ -1,0 +1,161 @@
+package packets
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+)
+
+// ErrShortPacket is returned when a component payload ends before all the
+// fields the protocol says it should contain have been read.
+//
+// Before this type existed every parser in this package indexed straight into
+// the payload slice, so a truncated or malformed packet took the whole process
+// down with an "index out of range" panic. A streaming client should never
+// crash because one frame arrived short.
+var ErrShortPacket = errors.New("packets: short packet")
+
+// cursor is a bounds-checked, little-endian sequential reader.
+//
+// The QTM real time protocol is a dense binary format and every parser here is
+// a long run of fixed offsets. Doing that arithmetic by hand is how bugs like
+// reading data[pos+8:pos+8] (a guaranteed panic) and forgetting to advance
+// between repeated records crept in. The cursor makes the stride explicit and
+// makes running off the end an error instead of a panic.
+type cursor struct {
+	data []byte
+	pos  int
+	err  error
+}
+
+func newCursor(data []byte) *cursor {
+	return &cursor{data: data}
+}
+
+// fail records the first error seen. Once a cursor is in the error state every
+// subsequent read is a no-op returning the zero value, so parsers can read a
+// whole record and check err once at the end rather than after every field.
+func (c *cursor) fail(err error) {
+	if c.err == nil {
+		c.err = err
+	}
+}
+
+// Err reports the first error encountered, if any.
+func (c *cursor) Err() error {
+	return c.err
+}
+
+// Remaining reports how many unread bytes are left.
+func (c *cursor) Remaining() int {
+	if c.err != nil {
+		return 0
+	}
+	return len(c.data) - c.pos
+}
+
+// need checks that n more bytes are available and returns the slice covering
+// them, advancing the position. It returns nil if the read would overrun.
+func (c *cursor) need(n int) []byte {
+	if c.err != nil {
+		return nil
+	}
+	if n < 0 || c.pos+n > len(c.data) {
+		c.fail(fmt.Errorf("%w: need %d bytes at offset %d, have %d",
+			ErrShortPacket, n, c.pos, len(c.data)-c.pos))
+		return nil
+	}
+	b := c.data[c.pos : c.pos+n]
+	c.pos += n
+	return b
+}
+
+func (c *cursor) Uint8() uint8 {
+	b := c.need(1)
+	if b == nil {
+		return 0
+	}
+	return b[0]
+}
+
+func (c *cursor) Uint16() uint16 {
+	b := c.need(2)
+	if b == nil {
+		return 0
+	}
+	return binary.LittleEndian.Uint16(b)
+}
+
+func (c *cursor) Uint32() uint32 {
+	b := c.need(4)
+	if b == nil {
+		return 0
+	}
+	return binary.LittleEndian.Uint32(b)
+}
+
+func (c *cursor) Uint64() uint64 {
+	b := c.need(8)
+	if b == nil {
+		return 0
+	}
+	return binary.LittleEndian.Uint64(b)
+}
+
+func (c *cursor) Float32() float32 {
+	b := c.need(4)
+	if b == nil {
+		return 0
+	}
+	return math.Float32frombits(binary.LittleEndian.Uint32(b))
+}
+
+// Point reads three consecutive float32 as an X/Y/Z triple.
+func (c *cursor) Point() Point {
+	return Point{X: c.Float32(), Y: c.Float32(), Z: c.Float32()}
+}
+
+// Bytes returns a copy of the next n bytes.
+//
+// A copy is deliberate: the protocol reuses one receive buffer for every frame,
+// so handing out a sub-slice would leave callers holding memory that the next
+// frame overwrites underneath them.
+func (c *cursor) Bytes(n int) []byte {
+	b := c.need(n)
+	if b == nil {
+		return nil
+	}
+	out := make([]byte, n)
+	copy(out, b)
+	return out
+}
+
+// Skip advances past n bytes without reading them.
+func (c *cursor) Skip(n int) {
+	c.need(n)
+}
+
+// checkCount guards against a corrupt or hostile record count causing a huge
+// allocation before any data is validated. minBytesEach is the smallest number
+// of bytes one record can occupy.
+func (c *cursor) checkCount(count uint32, minBytesEach int, what string) bool {
+	if c.err != nil {
+		return false
+	}
+	if minBytesEach > 0 && uint64(count)*uint64(minBytesEach) > uint64(c.Remaining()) {
+		c.fail(fmt.Errorf("%w: %s count %d exceeds %d remaining bytes",
+			ErrShortPacket, what, count, c.Remaining()))
+		return false
+	}
+	return true
+}
+
+// Float32frombytes decodes a little-endian float32.
+//
+// Deprecated: retained for backwards compatibility with code outside this
+// package. It panics on a slice shorter than four bytes; prefer the internal
+// cursor for anything parsing wire data.
+func Float32frombytes(b []byte) float32 {
+	return math.Float32frombits(binary.LittleEndian.Uint32(b))
+}

--- a/pkg/packets/eyetracker.go
+++ b/pkg/packets/eyetracker.go
@@ -1,9 +1,6 @@
 package packets
 
-import (
-	"encoding/binary"
-	"fmt"
-)
+import "fmt"
 
 type EyeTrackerSample struct {
 	LeftPupilDiameter  float32
@@ -19,6 +16,10 @@ type EyeTracker struct {
 	Samples      []EyeTrackerSample
 }
 
+func (e EyeTracker) String() string {
+	return fmt.Sprintf("[samplenumber: %v samples: %v]", e.SampleNumber, e.Samples)
+}
+
 type ComponentEyeTracker struct {
 	EyeTrackers []EyeTracker
 }
@@ -27,28 +28,37 @@ func (c ComponentEyeTracker) String() string {
 	return fmt.Sprintf("Eyetrackers: %v", c.EyeTrackers)
 }
 
+// UnmarshalBinary decodes eye tracker pupil diameters. As with gaze vectors, a
+// device reporting zero samples omits the sample number field.
 func (c *ComponentEyeTracker) UnmarshalBinary(data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
-	numberOfEyeTrackers := binary.LittleEndian.Uint32(data[0:4])
-	pos := 4
-	c.EyeTrackers = make([]EyeTracker, 0, numberOfEyeTrackers)
-	for m := uint32(0); m < numberOfEyeTrackers; m++ {
-		samples := binary.LittleEndian.Uint32(data[pos : pos+4])
-		if samples == 0 {
-			pos += 4
+	cur := newCursor(data)
+	deviceCount := cur.Uint32()
+	if !cur.checkCount(deviceCount, 4, "eye tracker") {
+		return cur.Err()
+	}
+
+	c.EyeTrackers = make([]EyeTracker, 0, deviceCount)
+	for i := uint32(0); i < deviceCount; i++ {
+		sampleCount := cur.Uint32()
+		if sampleCount == 0 {
+			c.EyeTrackers = append(c.EyeTrackers, EyeTracker{})
 			continue
 		}
-		sampleNumber := binary.LittleEndian.Uint32(data[pos+4 : pos+8])
-		s := make([]EyeTrackerSample, samples)
-		for i := uint32(0); i < samples; i++ {
-			s[i].LeftPupilDiameter = Float32frombytes(data[pos+8 : pos+12])
-			s[i].RightPupilDiameter = Float32frombytes(data[pos+12 : pos+16])
-			pos += 8
+		et := EyeTracker{SampleNumber: cur.Uint32()}
+		if !cur.checkCount(sampleCount, 8, "eye tracker sample") {
+			return cur.Err()
 		}
-		c.EyeTrackers = append(c.EyeTrackers, EyeTracker{SampleNumber: sampleNumber, Samples: s})
-		pos += 8
+		et.Samples = make([]EyeTrackerSample, sampleCount)
+		for s := uint32(0); s < sampleCount; s++ {
+			et.Samples[s] = EyeTrackerSample{
+				LeftPupilDiameter:  cur.Float32(),
+				RightPupilDiameter: cur.Float32(),
+			}
+		}
+		c.EyeTrackers = append(c.EyeTrackers, et)
 	}
-	return nil
+	return cur.Err()
 }

--- a/pkg/packets/force.go
+++ b/pkg/packets/force.go
@@ -2,7 +2,7 @@ package packets
 
 import "fmt"
 
-// Point is a position in 3D space, in millimetres.
+// Point is a position in 3D space, in millimeters.
 type Point struct {
 	X, Y, Z float32
 }
@@ -47,7 +47,7 @@ func (c ComponentForce) String() string {
 	return s
 }
 
-// forceSampleBytes is 9 float32: force, moment and centre of pressure.
+// forceSampleBytes is 9 float32: force, moment and center of pressure.
 const forceSampleBytes = 36
 
 func (c *ComponentForce) UnmarshalBinary(data []byte) error {

--- a/pkg/packets/force.go
+++ b/pkg/packets/force.go
@@ -1,9 +1,6 @@
 package packets
 
-import (
-	"encoding/binary"
-	"fmt"
-)
+import "fmt"
 
 type Point struct {
 	X, Y, Z float32
@@ -40,70 +37,69 @@ type ComponentForce struct {
 func (c ComponentForce) String() string {
 	var s string
 	for _, fp := range c.ForcePlates {
-		s += fmt.Sprintf("%v", fp.String())
+		s += fp.String()
 	}
 	return s
 }
+
+// forceSampleBytes is 9 float32: force, moment and centre of pressure.
+const forceSampleBytes = 36
 
 func (c *ComponentForce) UnmarshalBinary(data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
-	numberOfForcePlates := binary.LittleEndian.Uint32(data[0:4])
-	pos := 4
-	c.ForcePlates = make([]ForcePlate, 0, numberOfForcePlates)
-	for m := uint32(0); m < numberOfForcePlates; m++ {
-		fp := ForcePlate{}
-		fp.ID = binary.LittleEndian.Uint32(data[pos : pos+4])
-		samples := binary.LittleEndian.Uint32(data[pos+4 : pos+8])
-		fp.Number = binary.LittleEndian.Uint32(data[pos+8 : pos+12])
-		if samples > 0 {
-			fp.Samples = make([]ForceSample, samples)
-			for i := uint32(0); i < samples; i++ {
-				fp.Samples[i].Force.X = Float32frombytes(data[pos+12 : pos+16])
-				fp.Samples[i].Force.Y = Float32frombytes(data[pos+16 : pos+20])
-				fp.Samples[i].Force.Z = Float32frombytes(data[pos+20 : pos+24])
-				fp.Samples[i].Moment.X = Float32frombytes(data[pos+24 : pos+28])
-				fp.Samples[i].Moment.Y = Float32frombytes(data[pos+28 : pos+32])
-				fp.Samples[i].Moment.Z = Float32frombytes(data[pos+32 : pos+36])
-				fp.Samples[i].CenterOfPressure.X = Float32frombytes(data[pos+36 : pos+40])
-				fp.Samples[i].CenterOfPressure.Y = Float32frombytes(data[pos+40 : pos+44])
-				fp.Samples[i].CenterOfPressure.Z = Float32frombytes(data[pos+44 : pos+48])
-				pos += 36
-			}
+	cur := newCursor(data)
+	plateCount := cur.Uint32()
+	// 12 byte plate header: id, sample count, sample number.
+	if !cur.checkCount(plateCount, 12, "force plate") {
+		return cur.Err()
+	}
+
+	c.ForcePlates = make([]ForcePlate, 0, plateCount)
+	for i := uint32(0); i < plateCount; i++ {
+		fp := ForcePlate{ID: cur.Uint32()}
+		sampleCount := cur.Uint32()
+		fp.Number = cur.Uint32()
+		if !cur.checkCount(sampleCount, forceSampleBytes, "force sample") {
+			return cur.Err()
+		}
+		fp.Samples = make([]ForceSample, 0, sampleCount)
+		for s := uint32(0); s < sampleCount; s++ {
+			fp.Samples = append(fp.Samples, ForceSample{
+				Force:            cur.Point(),
+				Moment:           cur.Point(),
+				CenterOfPressure: cur.Point(),
+			})
 		}
 		c.ForcePlates = append(c.ForcePlates, fp)
-		pos += 12
 	}
-	return nil
+	return cur.Err()
 }
 
 type ComponentForceSingle ComponentForce
 
-func (c ComponentForceSingle) String() string {
-	return ComponentForce(c).String()
-}
+func (c ComponentForceSingle) String() string { return ComponentForce(c).String() }
 
 func (c *ComponentForceSingle) UnmarshalBinary(data []byte) error {
-	numberOfForcePlates := binary.LittleEndian.Uint32(data[0:4])
-	pos := 4
-	c.ForcePlates = make([]ForcePlate, 0, numberOfForcePlates)
-	for m := uint32(0); m < numberOfForcePlates; m++ {
-		fp := ForcePlate{}
-		fp.ID = binary.LittleEndian.Uint32(data[pos : pos+4])
-		fp.Samples = make([]ForceSample, 1)
-		fp.Samples[0].Force.X = Float32frombytes(data[pos+4 : pos+8])
-		fp.Samples[0].Force.Y = Float32frombytes(data[pos+8 : pos+12])
-		fp.Samples[0].Force.Z = Float32frombytes(data[pos+12 : pos+16])
-		fp.Samples[0].Moment.X = Float32frombytes(data[pos+16 : pos+20])
-		fp.Samples[0].Moment.Y = Float32frombytes(data[pos+20 : pos+24])
-		fp.Samples[0].Moment.Z = Float32frombytes(data[pos+24 : pos+28])
-		fp.Samples[0].CenterOfPressure.X = Float32frombytes(data[pos+28 : pos+32])
-		fp.Samples[0].CenterOfPressure.Y = Float32frombytes(data[pos+32 : pos+36])
-		fp.Samples[0].CenterOfPressure.Z = Float32frombytes(data[pos+36 : pos+40])
-		pos += 36
-		c.ForcePlates = append(c.ForcePlates, fp)
-		pos += 4
+	if len(data) == 0 {
+		return nil
 	}
-	return nil
+	cur := newCursor(data)
+	plateCount := cur.Uint32()
+	if !cur.checkCount(plateCount, 4+forceSampleBytes, "force plate") {
+		return cur.Err()
+	}
+
+	c.ForcePlates = make([]ForcePlate, 0, plateCount)
+	for i := uint32(0); i < plateCount; i++ {
+		fp := ForcePlate{ID: cur.Uint32()}
+		fp.Samples = []ForceSample{{
+			Force:            cur.Point(),
+			Moment:           cur.Point(),
+			CenterOfPressure: cur.Point(),
+		}}
+		c.ForcePlates = append(c.ForcePlates, fp)
+	}
+	return cur.Err()
 }

--- a/pkg/packets/force.go
+++ b/pkg/packets/force.go
@@ -2,8 +2,13 @@ package packets
 
 import "fmt"
 
+// Point is a position in 3D space, in millimetres.
 type Point struct {
 	X, Y, Z float32
+}
+
+func (p Point) String() string {
+	return fmt.Sprintf("(%.3f, %.3f, %.3f)", p.X, p.Y, p.Z)
 }
 
 type ForceSample struct {

--- a/pkg/packets/gazevector.go
+++ b/pkg/packets/gazevector.go
@@ -1,9 +1,6 @@
 package packets
 
-import (
-	"encoding/binary"
-	"fmt"
-)
+import "fmt"
 
 type GazeVectorSample struct {
 	X, Y, Z                         float32
@@ -22,6 +19,10 @@ type GazeVector struct {
 	Samples      []GazeVectorSample
 }
 
+func (g GazeVector) String() string {
+	return fmt.Sprintf("[samplenumber: %v samples: %v]", g.SampleNumber, g.Samples)
+}
+
 type ComponentGazeVector struct {
 	GazeVectors []GazeVector
 }
@@ -30,32 +31,40 @@ func (c ComponentGazeVector) String() string {
 	return fmt.Sprintf("GazeVectors: %v", c.GazeVectors)
 }
 
+// UnmarshalBinary decodes gaze vectors.
+//
+// A device with zero samples omits the sample number field entirely, so the
+// record is 4 bytes rather than 8. This matches the stride the C++ SDK uses:
+// 4 + (sampleCount == 0 ? 0 : 4) + sampleCount*24.
 func (c *ComponentGazeVector) UnmarshalBinary(data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
-	numberOfGazeVector := binary.LittleEndian.Uint32(data[0:4])
-	pos := 4
-	c.GazeVectors = make([]GazeVector, 0, numberOfGazeVector)
-	for m := uint32(0); m < numberOfGazeVector; m++ {
-		samples := binary.LittleEndian.Uint32(data[pos : pos+4])
-		if samples == 0 {
-			pos += 4
+	cur := newCursor(data)
+	deviceCount := cur.Uint32()
+	if !cur.checkCount(deviceCount, 4, "gaze vector") {
+		return cur.Err()
+	}
+
+	c.GazeVectors = make([]GazeVector, 0, deviceCount)
+	for i := uint32(0); i < deviceCount; i++ {
+		sampleCount := cur.Uint32()
+		if sampleCount == 0 {
+			c.GazeVectors = append(c.GazeVectors, GazeVector{})
 			continue
 		}
-		sampleNumber := binary.LittleEndian.Uint32(data[pos+4 : pos+8])
-		g := make([]GazeVectorSample, samples)
-		for i := uint32(0); i < samples; i++ {
-			g[i].X = Float32frombytes(data[pos+8 : pos+12])
-			g[i].Y = Float32frombytes(data[pos+12 : pos+16])
-			g[i].Z = Float32frombytes(data[pos+16 : pos+20])
-			g[i].PositionX = Float32frombytes(data[pos+20 : pos+24])
-			g[i].PositionY = Float32frombytes(data[pos+24 : pos+28])
-			g[i].PositionZ = Float32frombytes(data[pos+28 : pos+32])
-			pos += 24
+		gv := GazeVector{SampleNumber: cur.Uint32()}
+		if !cur.checkCount(sampleCount, 24, "gaze vector sample") {
+			return cur.Err()
 		}
-		c.GazeVectors = append(c.GazeVectors, GazeVector{SampleNumber: sampleNumber, Samples: g})
-		pos += 8
+		gv.Samples = make([]GazeVectorSample, sampleCount)
+		for s := uint32(0); s < sampleCount; s++ {
+			gv.Samples[s] = GazeVectorSample{
+				X: cur.Float32(), Y: cur.Float32(), Z: cur.Float32(),
+				PositionX: cur.Float32(), PositionY: cur.Float32(), PositionZ: cur.Float32(),
+			}
+		}
+		c.GazeVectors = append(c.GazeVectors, gv)
 	}
-	return nil
+	return cur.Err()
 }

--- a/pkg/packets/image.go
+++ b/pkg/packets/image.go
@@ -1,9 +1,6 @@
 package packets
 
-import (
-	"encoding/binary"
-	"fmt"
-)
+import "fmt"
 
 //go:generate stringer -type ImageFormatType -trimprefix ImageFormatType
 type ImageFormatType uint32
@@ -24,14 +21,13 @@ type Image struct {
 	Data                                     []byte
 }
 
+// String deliberately reports the payload length rather than dumping the bytes;
+// a single video frame is easily megabytes and printing it is never useful.
 func (c Image) String() string {
-	return fmt.Sprintf("[id: %v format: %v width: %v height: %v left: %v top: %v right: %v bottom: %v size: %v data: %v",
-		c.ID,
-		c.Format,
-		c.Width, c.Height,
+	return fmt.Sprintf("[id: %v format: %v width: %v height: %v left: %v top: %v right: %v bottom: %v size: %v data: %d bytes]",
+		c.ID, c.Format, c.Width, c.Height,
 		c.LeftCrop, c.TopCrop, c.RightCrop, c.BottomCrop,
-		c.Size,
-		c.Data,
+		c.Size, len(c.Data),
 	)
 }
 
@@ -39,33 +35,49 @@ type ComponentImage struct {
 	Images []Image
 }
 
-func (c ComponentImage) String() string {
-	return fmt.Sprintf("%v", c.Images)
-}
+func (c ComponentImage) String() string { return fmt.Sprintf("%v", c.Images) }
 
+// imageHeaderBytes is id, format, width, height, four crop floats and size.
+const imageHeaderBytes = 36
+
+// UnmarshalBinary decodes camera images.
+//
+// Two defects are fixed here. Width was read from a zero-length slice
+// (data[pos+8:pos+8]), which panicked on every image frame, and Data was
+// allocated with make([]byte, 0, size) before copy, so copy had nowhere to
+// write and every image came back empty.
 func (c *ComponentImage) UnmarshalBinary(data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
-	imageCount := binary.LittleEndian.Uint32(data[0:4])
-	pos := uint32(4)
+	cur := newCursor(data)
+	imageCount := cur.Uint32()
+	if !cur.checkCount(imageCount, imageHeaderBytes, "image") {
+		return cur.Err()
+	}
+
 	c.Images = make([]Image, 0, imageCount)
 	for i := uint32(0); i < imageCount; i++ {
-		image := Image{
-			ID:         binary.LittleEndian.Uint32(data[pos : pos+4]),
-			Format:     ImageFormatType(binary.LittleEndian.Uint32(data[pos+4 : pos+8])),
-			Width:      binary.LittleEndian.Uint32(data[pos+8 : pos+8]),
-			Height:     binary.LittleEndian.Uint32(data[pos+12 : pos+16]),
-			LeftCrop:   Float32frombytes(data[pos+16 : pos+20]),
-			TopCrop:    Float32frombytes(data[pos+20 : pos+24]),
-			RightCrop:  Float32frombytes(data[pos+24 : pos+28]),
-			BottomCrop: Float32frombytes(data[pos+28 : pos+32]),
-			Size:       binary.LittleEndian.Uint32(data[pos+32 : pos+36]),
+		img := Image{
+			ID:         cur.Uint32(),
+			Format:     ImageFormatType(cur.Uint32()),
+			Width:      cur.Uint32(),
+			Height:     cur.Uint32(),
+			LeftCrop:   cur.Float32(),
+			TopCrop:    cur.Float32(),
+			RightCrop:  cur.Float32(),
+			BottomCrop: cur.Float32(),
 		}
-		image.Data = make([]byte, 0, image.Size)
-		copy(image.Data, data[pos+36:pos+36+image.Size])
-		pos += 36 + image.Size
-		c.Images = append(c.Images, image)
+		img.Size = cur.Uint32()
+		if cur.Err() != nil {
+			return cur.Err()
+		}
+		if uint64(img.Size) > uint64(cur.Remaining()) {
+			return fmt.Errorf("%w: image %d claims %d bytes, %d remaining",
+				ErrShortPacket, img.ID, img.Size, cur.Remaining())
+		}
+		img.Data = cur.Bytes(int(img.Size))
+		c.Images = append(c.Images, img)
 	}
-	return nil
+	return cur.Err()
 }

--- a/pkg/packets/image.go
+++ b/pkg/packets/image.go
@@ -24,7 +24,8 @@ type Image struct {
 // String deliberately reports the payload length rather than dumping the bytes;
 // a single video frame is easily megabytes and printing it is never useful.
 func (c Image) String() string {
-	return fmt.Sprintf("[id: %v format: %v width: %v height: %v left: %v top: %v right: %v bottom: %v size: %v data: %d bytes]",
+	return fmt.Sprintf(
+		"[id: %v format: %v width: %v height: %v left: %v top: %v right: %v bottom: %v size: %v data: %d bytes]",
 		c.ID, c.Format, c.Width, c.Height,
 		c.LeftCrop, c.TopCrop, c.RightCrop, c.BottomCrop,
 		c.Size, len(c.Data),

--- a/pkg/packets/markers2d.go
+++ b/pkg/packets/markers2d.go
@@ -1,28 +1,30 @@
 package packets
 
-import (
-	"encoding/binary"
-	"fmt"
-)
+import "fmt"
 
+// Marker2D is a marker as seen by a single camera. Positions and diameters are
+// in camera sensor subpixel units.
 type Marker2D struct {
 	X         uint32
 	Y         uint32
 	DiameterX uint16
-	DiamererY uint16
+	DiameterY uint16
 }
 
 func (m Marker2D) String() string {
-	return fmt.Sprintf("[x:%v y:%v dx:%v dy:%v]", m.X, m.Y, m.DiameterX, m.DiamererY)
+	return fmt.Sprintf("[x:%v y:%v dx:%v dy:%v]", m.X, m.Y, m.DiameterX, m.DiameterY)
 }
 
+// Camera holds the 2D markers seen by one camera.
 type Camera struct {
 	Markers []Marker2D
 	Status  uint8
 }
 
-func (m Camera) String() string {
-	return fmt.Sprintf("Status: %v Markers2D: %v", m.Markers, m.Status)
+func (c Camera) String() string {
+	// The previous implementation passed Markers where Status was formatted and
+	// vice versa, so every 2D dump printed the two fields swapped.
+	return fmt.Sprintf("Status: %v Markers2D: %v", c.Status, c.Markers)
 }
 
 type Component2D struct {
@@ -35,63 +37,51 @@ func (c Component2D) String() string {
 	return fmt.Sprintf("Droprate: %v OutOfSyncRate: %v Cameras: %v", c.Droprate, c.OutOfSyncRate, c.Cameras)
 }
 
-func (c *Component2D) UnmarshalBinary(data []byte) error {
-	numberOfCameras := binary.LittleEndian.Uint32(data[0:4])
-	c.Droprate = binary.LittleEndian.Uint16(data[4:6])
-	c.OutOfSyncRate = binary.LittleEndian.Uint16(data[6:8])
-	pos := 8
-	c.Cameras = make([]Camera, 0, numberOfCameras)
-	for m := uint32(0); m < numberOfCameras; m++ {
-		numberOfMarkers := binary.LittleEndian.Uint32(data[pos : pos+4])
-		camera := Camera{}
-		camera.Status = data[pos+4]
-		camera.Markers = make([]Marker2D, 0, numberOfMarkers)
-		for m := uint32(0); m < numberOfMarkers; m++ {
-			camera.Markers = append(camera.Markers, Marker2D{
-				X:         binary.LittleEndian.Uint32(data[pos+5 : pos+9]),
-				Y:         binary.LittleEndian.Uint32(data[pos+9 : pos+13]),
-				DiameterX: binary.LittleEndian.Uint16(data[pos+13 : pos+15]),
-				DiamererY: binary.LittleEndian.Uint16(data[pos+15 : pos+17]),
-			})
-			pos += 12
-		}
-		pos += 5
-		c.Cameras = append(c.Cameras, camera)
+func unmarshal2D(c *Component2D, data []byte) error {
+	if len(data) == 0 {
+		return nil
 	}
-	return nil
+	cur := newCursor(data)
+	cameraCount := cur.Uint32()
+	c.Droprate = cur.Uint16()
+	c.OutOfSyncRate = cur.Uint16()
+
+	// Each camera block is 4 bytes marker count + 1 byte status flags, then
+	// 12 bytes per marker.
+	const cameraHeader = 5
+	if !cur.checkCount(cameraCount, cameraHeader, "2d camera") {
+		return cur.Err()
+	}
+
+	c.Cameras = make([]Camera, 0, cameraCount)
+	for i := uint32(0); i < cameraCount; i++ {
+		markerCount := cur.Uint32()
+		cam := Camera{Status: cur.Uint8()}
+		if !cur.checkCount(markerCount, 12, "2d marker") {
+			return cur.Err()
+		}
+		cam.Markers = make([]Marker2D, 0, markerCount)
+		for m := uint32(0); m < markerCount; m++ {
+			cam.Markers = append(cam.Markers, Marker2D{
+				X:         cur.Uint32(),
+				Y:         cur.Uint32(),
+				DiameterX: cur.Uint16(),
+				DiameterY: cur.Uint16(),
+			})
+		}
+		c.Cameras = append(c.Cameras, cam)
+	}
+	return cur.Err()
+}
+
+func (c *Component2D) UnmarshalBinary(data []byte) error {
+	return unmarshal2D(c, data)
 }
 
 type Component2DLinearized Component2D
 
-func (c Component2DLinearized) String() string {
-	return fmt.Sprintf("Droprate: %v OutOfSyncRate: %v Cameras: %v", c.Droprate, c.OutOfSyncRate, c.Cameras)
-}
+func (c Component2DLinearized) String() string { return Component2D(c).String() }
 
 func (c *Component2DLinearized) UnmarshalBinary(data []byte) error {
-	if len(data) == 0 {
-		return nil
-	}
-	numberOfCameras := binary.LittleEndian.Uint32(data[0:4])
-	c.Droprate = binary.LittleEndian.Uint16(data[4:6])
-	c.OutOfSyncRate = binary.LittleEndian.Uint16(data[6:8])
-	pos := 8
-	c.Cameras = make([]Camera, 0, numberOfCameras)
-	for m := uint32(0); m < numberOfCameras; m++ {
-		numberOfMarkers := binary.LittleEndian.Uint32(data[pos : pos+4])
-		camera := Camera{}
-		camera.Status = data[pos+4]
-		camera.Markers = make([]Marker2D, 0, numberOfMarkers)
-		for m := uint32(0); m < numberOfMarkers; m++ {
-			camera.Markers = append(camera.Markers, Marker2D{
-				X:         binary.LittleEndian.Uint32(data[pos+5 : pos+9]),
-				Y:         binary.LittleEndian.Uint32(data[pos+9 : pos+13]),
-				DiameterX: binary.LittleEndian.Uint16(data[pos+13 : pos+15]),
-				DiamererY: binary.LittleEndian.Uint16(data[pos+15 : pos+17]),
-			})
-			pos += 12
-		}
-		pos += 5
-		c.Cameras = append(c.Cameras, camera)
-	}
-	return nil
+	return unmarshal2D((*Component2D)(c), data)
 }

--- a/pkg/packets/markers3d.go
+++ b/pkg/packets/markers3d.go
@@ -1,9 +1,6 @@
 package packets
 
-import (
-	"encoding/binary"
-	"fmt"
-)
+import "fmt"
 
 type Marker struct {
 	Point    Point
@@ -15,6 +12,12 @@ func (m Marker) String() string {
 	return fmt.Sprintf("[id: %v x:%v y:%v z:%v r:%v]", m.ID, m.Point.X, m.Point.Y, m.Point.Z, m.Residual)
 }
 
+// Component3D holds labelled 3D markers.
+//
+// Markers arrive in the same order as the labels in the 3D settings XML, so
+// index N here corresponds to label N from GetParameters 3D. The wire format
+// carries no per-marker ID for labelled markers; ID is only populated for the
+// NoLabels variants.
 type Component3D struct {
 	Droprate      uint16
 	OutOfSyncRate uint16
@@ -25,103 +28,66 @@ func (c Component3D) String() string {
 	return fmt.Sprintf("Droprate: %v OutOfSyncRate: %v Markers: %v", c.Droprate, c.OutOfSyncRate, c.Markers)
 }
 
-func (c *Component3D) UnmarshalBinary(data []byte) error {
+// unmarshal3D is shared by all four 3D variants. bytesPerMarker documents the
+// stride so the record layout is stated once instead of open-coded four times.
+func unmarshal3D(c *Component3D, data []byte, withID, withResidual bool) error {
 	if len(data) == 0 {
 		return nil
 	}
-	numberOfMarkers := binary.LittleEndian.Uint32(data[0:4])
-	c.Droprate = binary.LittleEndian.Uint16(data[4:6])
-	c.OutOfSyncRate = binary.LittleEndian.Uint16(data[6:8])
-	pos := 8
-	c.Markers = make([]Marker, 0, numberOfMarkers)
-	for m := uint32(0); m < numberOfMarkers; m++ {
-		c.Markers = append(c.Markers, Marker{
-			Point: Point{
-				X: Float32frombytes(data[pos : pos+4]),
-				Y: Float32frombytes(data[pos+4 : pos+8]),
-				Z: Float32frombytes(data[pos+8 : pos+12]),
-			},
-		})
-		pos += 12
+	cur := newCursor(data)
+	count := cur.Uint32()
+	c.Droprate = cur.Uint16()
+	c.OutOfSyncRate = cur.Uint16()
+
+	stride := 12
+	if withID {
+		stride += 4
 	}
-	return nil
+	if withResidual {
+		stride += 4
+	}
+	if !cur.checkCount(count, stride, "3d marker") {
+		return cur.Err()
+	}
+
+	c.Markers = make([]Marker, 0, count)
+	for i := uint32(0); i < count; i++ {
+		m := Marker{Point: cur.Point()}
+		if withID {
+			m.ID = cur.Uint32()
+		}
+		if withResidual {
+			m.Residual = cur.Float32()
+		}
+		c.Markers = append(c.Markers, m)
+	}
+	return cur.Err()
+}
+
+func (c *Component3D) UnmarshalBinary(data []byte) error {
+	return unmarshal3D(c, data, false, false)
 }
 
 type Component3DResidual Component3D
 
-func (c Component3DResidual) String() string {
-	return Component3D(c).String()
-}
+func (c Component3DResidual) String() string { return Component3D(c).String() }
 
 func (c *Component3DResidual) UnmarshalBinary(data []byte) error {
-	numberOfMarkers := binary.LittleEndian.Uint32(data[0:4])
-	c.Droprate = binary.LittleEndian.Uint16(data[4:6])
-	c.OutOfSyncRate = binary.LittleEndian.Uint16(data[6:8])
-	pos := 8
-	c.Markers = make([]Marker, 0, numberOfMarkers)
-	for m := uint32(0); m < numberOfMarkers; m++ {
-		c.Markers = append(c.Markers, Marker{
-			Point: Point{
-				X: Float32frombytes(data[pos : pos+4]),
-				Y: Float32frombytes(data[pos+4 : pos+8]),
-				Z: Float32frombytes(data[pos+8 : pos+12]),
-			},
-			Residual: Float32frombytes(data[pos+12 : pos+16]),
-		})
-		pos += 16
-	}
-	return nil
+	return unmarshal3D((*Component3D)(c), data, false, true)
 }
 
 type Component3DNoLabels Component3D
 
-func (c Component3DNoLabels) String() string {
-	return Component3D(c).String()
-}
+func (c Component3DNoLabels) String() string { return Component3D(c).String() }
 
 func (c *Component3DNoLabels) UnmarshalBinary(data []byte) error {
-	numberOfMarkers := binary.LittleEndian.Uint32(data[0:4])
-	c.Droprate = binary.LittleEndian.Uint16(data[4:6])
-	c.OutOfSyncRate = binary.LittleEndian.Uint16(data[6:8])
-	pos := 8
-	c.Markers = make([]Marker, 0, numberOfMarkers)
-	for m := uint32(0); m < numberOfMarkers; m++ {
-		c.Markers = append(c.Markers, Marker{
-			Point: Point{
-				X: Float32frombytes(data[pos : pos+4]),
-				Y: Float32frombytes(data[pos+4 : pos+8]),
-				Z: Float32frombytes(data[pos+8 : pos+12]),
-			},
-			ID: binary.LittleEndian.Uint32(data[pos+12 : pos+16]),
-		})
-		pos += 16
-	}
-	return nil
+	return unmarshal3D((*Component3D)(c), data, true, false)
 }
 
 type Component3DNoLabelsResidual Component3D
 
-func (c Component3DNoLabelsResidual) String() string {
-	return Component3D(c).String()
-}
+func (c Component3DNoLabelsResidual) String() string { return Component3D(c).String() }
 
 func (c *Component3DNoLabelsResidual) UnmarshalBinary(data []byte) error {
-	numberOfMarkers := binary.LittleEndian.Uint32(data[0:4])
-	c.Droprate = binary.LittleEndian.Uint16(data[4:6])
-	c.OutOfSyncRate = binary.LittleEndian.Uint16(data[6:8])
-	pos := 8
-	c.Markers = make([]Marker, 0, numberOfMarkers)
-	for m := uint32(0); m < numberOfMarkers; m++ {
-		c.Markers = append(c.Markers, Marker{
-			Point: Point{
-				X: Float32frombytes(data[pos : pos+4]),
-				Y: Float32frombytes(data[pos+4 : pos+8]),
-				Z: Float32frombytes(data[pos+8 : pos+12]),
-			},
-			ID:       binary.LittleEndian.Uint32(data[pos+12 : pos+16]),
-			Residual: Float32frombytes(data[pos+16 : pos+20]),
-		})
-		pos += 20
-	}
-	return nil
+	return unmarshal3D((*Component3D)(c), data, true, true)
 }

--- a/pkg/packets/markers3d.go
+++ b/pkg/packets/markers3d.go
@@ -12,11 +12,11 @@ func (m Marker) String() string {
 	return fmt.Sprintf("[id: %v x:%v y:%v z:%v r:%v]", m.ID, m.Point.X, m.Point.Y, m.Point.Z, m.Residual)
 }
 
-// Component3D holds labelled 3D markers.
+// Component3D holds labeled 3D markers.
 //
 // Markers arrive in the same order as the labels in the 3D settings XML, so
 // index N here corresponds to label N from GetParameters 3D. The wire format
-// carries no per-marker ID for labelled markers; ID is only populated for the
+// carries no per-marker ID for labeled markers; ID is only populated for the
 // NoLabels variants.
 type Component3D struct {
 	Droprate      uint16

--- a/pkg/packets/objects.go
+++ b/pkg/packets/objects.go
@@ -1,9 +1,6 @@
 package packets
 
-import (
-	"encoding/binary"
-	"fmt"
-)
+import "fmt"
 
 type BodyMatrix struct {
 	Point    Point
@@ -21,6 +18,8 @@ func (b BodyMatrix) String() string {
 	)
 }
 
+// Component6D holds 6DOF bodies as position plus a row-major 3x3 rotation
+// matrix. Bodies arrive in the order they appear in the 6D settings XML.
 type Component6D struct {
 	Droprate      uint16
 	OutOfSyncRate uint16
@@ -31,60 +30,47 @@ func (c Component6D) String() string {
 	return fmt.Sprintf("Droprate: %v OutOfSyncRate: %v Bodies: %v\n", c.Droprate, c.OutOfSyncRate, c.Bodies)
 }
 
-func (c *Component6D) UnmarshalBinary(data []byte) error {
+func unmarshal6D(c *Component6D, data []byte, withResidual bool) error {
 	if len(data) == 0 {
 		return nil
 	}
-	numberOfBodies := binary.LittleEndian.Uint32(data[0:4])
-	c.Droprate = binary.LittleEndian.Uint16(data[4:6])
-	c.OutOfSyncRate = binary.LittleEndian.Uint16(data[6:8])
-	pos := 8
-	c.Bodies = make([]BodyMatrix, 0, numberOfBodies)
-	for m := uint32(0); m < numberOfBodies; m++ {
-		body := BodyMatrix{
-			Point: Point{
-				X: Float32frombytes(data[pos : pos+4]),
-				Y: Float32frombytes(data[pos+4 : pos+8]),
-				Z: Float32frombytes(data[pos+8 : pos+12]),
-			},
+	cur := newCursor(data)
+	count := cur.Uint32()
+	c.Droprate = cur.Uint16()
+	c.OutOfSyncRate = cur.Uint16()
+
+	stride := 48 // 3 floats position + 9 floats rotation
+	if withResidual {
+		stride += 4
+	}
+	if !cur.checkCount(count, stride, "6d body") {
+		return cur.Err()
+	}
+
+	c.Bodies = make([]BodyMatrix, 0, count)
+	for i := uint32(0); i < count; i++ {
+		body := BodyMatrix{Point: cur.Point()}
+		for r := 0; r < 9; r++ {
+			body.Rotation[r] = cur.Float32()
 		}
-		for i := 0; i < 9; i++ {
-			body.Rotation[i] = Float32frombytes(data[pos+12+i*4 : pos+16+i*4])
+		if withResidual {
+			body.Residual = cur.Float32()
 		}
 		c.Bodies = append(c.Bodies, body)
-		pos += 48
 	}
-	return nil
+	return cur.Err()
+}
+
+func (c *Component6D) UnmarshalBinary(data []byte) error {
+	return unmarshal6D(c, data, false)
 }
 
 type Component6DResidual Component6D
 
-func (c Component6DResidual) String() string {
-	return Component6D(c).String()
-}
+func (c Component6DResidual) String() string { return Component6D(c).String() }
 
 func (c *Component6DResidual) UnmarshalBinary(data []byte) error {
-	numberOfBodies := binary.LittleEndian.Uint32(data[0:4])
-	c.Droprate = binary.LittleEndian.Uint16(data[4:6])
-	c.OutOfSyncRate = binary.LittleEndian.Uint16(data[6:8])
-	pos := 8
-	c.Bodies = make([]BodyMatrix, 0, numberOfBodies)
-	for m := uint32(0); m < numberOfBodies; m++ {
-		body := BodyMatrix{
-			Point: Point{
-				X: Float32frombytes(data[pos : pos+4]),
-				Y: Float32frombytes(data[pos+4 : pos+8]),
-				Z: Float32frombytes(data[pos+8 : pos+12]),
-			},
-		}
-		for i := 0; i < 9; i++ {
-			body.Rotation[i] = Float32frombytes(data[pos+12+i*4 : pos+16+i*4])
-		}
-		body.Residual = Float32frombytes(data[pos+48 : pos+52])
-		c.Bodies = append(c.Bodies, body)
-		pos += 52
-	}
-	return nil
+	return unmarshal6D((*Component6D)(c), data, true)
 }
 
 type BodyEuler struct {
@@ -101,6 +87,9 @@ func (b BodyEuler) String() string {
 	)
 }
 
+// Component6DEuler holds 6DOF bodies as position plus Euler angles. The angle
+// convention is reported by the General settings XML (the Euler element), so it
+// is not fixed by this struct.
 type Component6DEuler struct {
 	Droprate      uint16
 	OutOfSyncRate uint16
@@ -111,55 +100,45 @@ func (c Component6DEuler) String() string {
 	return fmt.Sprintf("Droprate: %v OutOfSyncRate: %v Bodies: %v\n", c.Droprate, c.OutOfSyncRate, c.Bodies)
 }
 
-func (c *Component6DEuler) UnmarshalBinary(data []byte) error {
-	numberOfBodies := binary.LittleEndian.Uint32(data[0:4])
-	c.Droprate = binary.LittleEndian.Uint16(data[4:6])
-	c.OutOfSyncRate = binary.LittleEndian.Uint16(data[6:8])
-	pos := 8
-	c.Bodies = make([]BodyEuler, 0, numberOfBodies)
-	for m := uint32(0); m < numberOfBodies; m++ {
-		body := BodyEuler{
-			Point: Point{
-				X: Float32frombytes(data[pos : pos+4]),
-				Y: Float32frombytes(data[pos+4 : pos+8]),
-				Z: Float32frombytes(data[pos+8 : pos+12]),
-			},
+func unmarshal6DEuler(c *Component6DEuler, data []byte, withResidual bool) error {
+	if len(data) == 0 {
+		return nil
+	}
+	cur := newCursor(data)
+	count := cur.Uint32()
+	c.Droprate = cur.Uint16()
+	c.OutOfSyncRate = cur.Uint16()
+
+	stride := 24 // 3 floats position + 3 floats angles
+	if withResidual {
+		stride += 4
+	}
+	if !cur.checkCount(count, stride, "6d euler body") {
+		return cur.Err()
+	}
+
+	c.Bodies = make([]BodyEuler, 0, count)
+	for i := uint32(0); i < count; i++ {
+		body := BodyEuler{Point: cur.Point()}
+		for a := 0; a < 3; a++ {
+			body.Angles[a] = cur.Float32()
 		}
-		for i := 0; i < 3; i++ {
-			body.Angles[i] = Float32frombytes(data[pos+12+i*4 : pos+16+i*4])
+		if withResidual {
+			body.Residual = cur.Float32()
 		}
 		c.Bodies = append(c.Bodies, body)
-		pos += 24
 	}
-	return nil
+	return cur.Err()
+}
+
+func (c *Component6DEuler) UnmarshalBinary(data []byte) error {
+	return unmarshal6DEuler(c, data, false)
 }
 
 type Component6DEulerResidual Component6DEuler
 
-func (c Component6DEulerResidual) String() string {
-	return Component6DEuler(c).String()
-}
+func (c Component6DEulerResidual) String() string { return Component6DEuler(c).String() }
 
 func (c *Component6DEulerResidual) UnmarshalBinary(data []byte) error {
-	numberOfBodies := binary.LittleEndian.Uint32(data[0:4])
-	c.Droprate = binary.LittleEndian.Uint16(data[4:6])
-	c.OutOfSyncRate = binary.LittleEndian.Uint16(data[6:8])
-	pos := 8
-	c.Bodies = make([]BodyEuler, 0, numberOfBodies)
-	for m := uint32(0); m < numberOfBodies; m++ {
-		body := BodyEuler{
-			Point: Point{
-				X: Float32frombytes(data[pos : pos+4]),
-				Y: Float32frombytes(data[pos+4 : pos+8]),
-				Z: Float32frombytes(data[pos+8 : pos+12]),
-			},
-		}
-		for i := 0; i < 3; i++ {
-			body.Angles[i] = Float32frombytes(data[pos+12+i*4 : pos+16+i*4])
-		}
-		body.Residual = Float32frombytes(data[pos+24 : pos+28])
-		c.Bodies = append(c.Bodies, body)
-		pos += 28
-	}
-	return nil
+	return unmarshal6DEuler((*Component6DEuler)(c), data, true)
 }

--- a/pkg/packets/packets_test.go
+++ b/pkg/packets/packets_test.go
@@ -11,17 +11,21 @@ import (
 type builder struct{ b []byte }
 
 func (w *builder) u8(v uint8) *builder { w.b = append(w.b, v); return w }
+
 func (w *builder) u16(v uint16) *builder {
 	w.b = binary.LittleEndian.AppendUint16(w.b, v)
 	return w
 }
+
 func (w *builder) u32(v uint32) *builder {
 	w.b = binary.LittleEndian.AppendUint32(w.b, v)
 	return w
 }
+
 func (w *builder) f32(v float32) *builder {
 	return w.u32(math.Float32bits(v))
 }
+
 func (w *builder) raw(p []byte) *builder { w.b = append(w.b, p...); return w }
 
 func TestComponentImageDecodesHeaderAndPayload(t *testing.T) {

--- a/pkg/packets/packets_test.go
+++ b/pkg/packets/packets_test.go
@@ -1,0 +1,401 @@
+package packets
+
+import (
+	"encoding/binary"
+	"errors"
+	"math"
+	"testing"
+)
+
+// builder assembles little-endian component payloads for tests.
+type builder struct{ b []byte }
+
+func (w *builder) u8(v uint8) *builder { w.b = append(w.b, v); return w }
+func (w *builder) u16(v uint16) *builder {
+	w.b = binary.LittleEndian.AppendUint16(w.b, v)
+	return w
+}
+func (w *builder) u32(v uint32) *builder {
+	w.b = binary.LittleEndian.AppendUint32(w.b, v)
+	return w
+}
+func (w *builder) f32(v float32) *builder {
+	return w.u32(math.Float32bits(v))
+}
+func (w *builder) raw(p []byte) *builder { w.b = append(w.b, p...); return w }
+
+func TestComponentImageDecodesHeaderAndPayload(t *testing.T) {
+	// Regression: Width was read from data[pos+8:pos+8], a zero-length slice,
+	// which panicked on every image frame. Data was allocated with length zero
+	// before copy, so the payload was always dropped.
+	payload := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01}
+	b := (&builder{}).
+		u32(1).    // image count
+		u32(7).    // camera id
+		u32(2).    // format: JPG
+		u32(1920). // width
+		u32(1080). // height
+		f32(0.1).f32(0.2).f32(0.3).f32(0.4).
+		u32(uint32(len(payload))).
+		raw(payload)
+
+	var c ComponentImage
+	if err := c.UnmarshalBinary(b.b); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(c.Images) != 1 {
+		t.Fatalf("got %d images, want 1", len(c.Images))
+	}
+	img := c.Images[0]
+	if img.ID != 7 || img.Format != ImageFormatTypeJPG {
+		t.Errorf("id=%d format=%v", img.ID, img.Format)
+	}
+	if img.Width != 1920 {
+		t.Errorf("width = %d, want 1920", img.Width)
+	}
+	if img.Height != 1080 {
+		t.Errorf("height = %d, want 1080", img.Height)
+	}
+	if string(img.Data) != string(payload) {
+		t.Errorf("data = %v, want %v", img.Data, payload)
+	}
+}
+
+func TestComponentImageRejectsOversizedPayload(t *testing.T) {
+	b := (&builder{}).
+		u32(1).u32(1).u32(0).u32(4).u32(4).
+		f32(0).f32(0).f32(0).f32(0).
+		u32(1 << 30) // claims a gigabyte that is not there
+
+	var c ComponentImage
+	err := c.UnmarshalBinary(b.b)
+	if err == nil {
+		t.Fatal("expected an error for an oversized image payload")
+	}
+	if !errors.Is(err, ErrShortPacket) {
+		t.Errorf("got %v, want ErrShortPacket", err)
+	}
+}
+
+func TestComponentTimecodeAdvancesBetweenEntries(t *testing.T) {
+	// Regression: every entry was decoded from the same three fixed offsets, so
+	// a stream carrying N timecodes reported the first one N times.
+	b := (&builder{}).
+		u32(2).
+		u32(uint32(TimecodeTypeSMPTE)).u32(0).u32(encodeSMPTE(1, 2, 3, 4, 5)).
+		u32(uint32(TimecodeTypeSMPTE)).u32(0).u32(encodeSMPTE(6, 7, 8, 9, 10))
+
+	var c ComponentTimecode
+	if err := c.UnmarshalBinary(b.b); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(c.Timecodes) != 2 {
+		t.Fatalf("got %d timecodes, want 2", len(c.Timecodes))
+	}
+	first, second := c.Timecodes[0].Smpte, c.Timecodes[1].Smpte
+	if first.Hour != 1 || first.Minute != 2 || first.Second != 3 || first.Frame != 4 || first.SubFrame != 5 {
+		t.Errorf("first = %+v", first)
+	}
+	if second.Hour != 6 || second.Minute != 7 || second.Second != 8 || second.Frame != 9 || second.SubFrame != 10 {
+		t.Errorf("second = %+v, entries were not advanced", second)
+	}
+}
+
+func encodeSMPTE(h, m, s, f, sub uint32) uint32 {
+	return h | m<<5 | s<<11 | f<<17 | sub<<22
+}
+
+func TestSmpteNormalizedSubFrame(t *testing.T) {
+	tc := SmpteTime{SubFrame: 3}
+	if got := tc.NormalizedSubFrame(120, 30); got != 0.75 {
+		t.Errorf("got %v, want 0.75", got)
+	}
+	// Guard against divide-by-zero and inverted frequencies.
+	if got := tc.NormalizedSubFrame(0, 30); got != 0 {
+		t.Errorf("zero capture frequency: got %v, want 0", got)
+	}
+	if got := tc.NormalizedSubFrame(30, 120); got != 0 {
+		t.Errorf("capture below timestamp frequency: got %v, want 0", got)
+	}
+}
+
+func TestComponent3DVariantStrides(t *testing.T) {
+	cases := []struct {
+		name         string
+		obj          interface{ UnmarshalBinary([]byte) error }
+		withID       bool
+		withResidual bool
+	}{
+		{"3D", &Component3D{}, false, false},
+		{"3DRes", &Component3DResidual{}, false, true},
+		{"3DNoLabels", &Component3DNoLabels{}, true, false},
+		{"3DNoLabelsRes", &Component3DNoLabelsResidual{}, true, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := (&builder{}).u32(2).u16(11).u16(22)
+			for i := 0; i < 2; i++ {
+				w.f32(float32(i)).f32(float32(i) + 0.5).f32(float32(i) + 0.25)
+				if tc.withID {
+					w.u32(uint32(100 + i))
+				}
+				if tc.withResidual {
+					w.f32(float32(i) * 2)
+				}
+			}
+			if err := tc.obj.UnmarshalBinary(w.b); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			c := (*Component3D)(nil)
+			switch v := tc.obj.(type) {
+			case *Component3D:
+				c = v
+			case *Component3DResidual:
+				c = (*Component3D)(v)
+			case *Component3DNoLabels:
+				c = (*Component3D)(v)
+			case *Component3DNoLabelsResidual:
+				c = (*Component3D)(v)
+			}
+			if c.Droprate != 11 || c.OutOfSyncRate != 22 {
+				t.Errorf("droprate=%d oosrate=%d", c.Droprate, c.OutOfSyncRate)
+			}
+			if len(c.Markers) != 2 {
+				t.Fatalf("got %d markers, want 2", len(c.Markers))
+			}
+			if c.Markers[1].Point.X != 1 {
+				t.Errorf("second marker X = %v, want 1", c.Markers[1].Point.X)
+			}
+			if tc.withID && c.Markers[1].ID != 101 {
+				t.Errorf("second marker ID = %d, want 101", c.Markers[1].ID)
+			}
+			if tc.withResidual && c.Markers[1].Residual != 2 {
+				t.Errorf("second marker residual = %v, want 2", c.Markers[1].Residual)
+			}
+		})
+	}
+}
+
+func TestComponent2DCameraStride(t *testing.T) {
+	// Two cameras with different marker counts exercises the 5 byte camera
+	// header plus 12 bytes per marker stride.
+	w := (&builder{}).u32(2).u16(0).u16(0)
+	w.u32(2).u8(0x01)
+	w.u32(10).u32(20).u16(3).u16(4)
+	w.u32(11).u32(21).u16(5).u16(6)
+	w.u32(1).u8(0x02)
+	w.u32(30).u32(40).u16(7).u16(8)
+
+	var c Component2D
+	if err := c.UnmarshalBinary(w.b); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(c.Cameras) != 2 {
+		t.Fatalf("got %d cameras, want 2", len(c.Cameras))
+	}
+	if len(c.Cameras[0].Markers) != 2 || len(c.Cameras[1].Markers) != 1 {
+		t.Fatalf("marker counts = %d, %d", len(c.Cameras[0].Markers), len(c.Cameras[1].Markers))
+	}
+	if c.Cameras[1].Status != 0x02 {
+		t.Errorf("second camera status = %#x, want 0x02", c.Cameras[1].Status)
+	}
+	if got := c.Cameras[1].Markers[0]; got.X != 30 || got.Y != 40 || got.DiameterX != 7 || got.DiameterY != 8 {
+		t.Errorf("second camera marker = %+v", got)
+	}
+}
+
+func TestComponentSkeletonSegments(t *testing.T) {
+	w := (&builder{}).u32(2)
+	// Skeleton 0: two segments.
+	w.u32(2)
+	w.u32(1).f32(1).f32(2).f32(3).f32(0).f32(0).f32(0).f32(1)
+	w.u32(2).f32(4).f32(5).f32(6).f32(0).f32(0).f32(1).f32(0)
+	// Skeleton 1: one segment.
+	w.u32(1)
+	w.u32(9).f32(7).f32(8).f32(9).f32(1).f32(0).f32(0).f32(0)
+
+	var c ComponentSkeleton
+	if err := c.UnmarshalBinary(w.b); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(c.Skeletons) != 2 {
+		t.Fatalf("got %d skeletons, want 2", len(c.Skeletons))
+	}
+	if len(c.Skeletons[0].Segments) != 2 || len(c.Skeletons[1].Segments) != 1 {
+		t.Fatalf("segment counts = %d, %d", len(c.Skeletons[0].Segments), len(c.Skeletons[1].Segments))
+	}
+	if got := c.Skeletons[1].Segments[0]; got.ID != 9 || got.Position.X != 7 || got.Rotation.X != 1 {
+		t.Errorf("second skeleton segment = %+v", got)
+	}
+}
+
+func TestComponentAnalogGroupsSamplesByChannel(t *testing.T) {
+	w := (&builder{}).u32(1)
+	w.u32(5).u32(2).u32(3).u32(42) // device 5, 2 channels, 3 samples, sample number 42
+	w.f32(1).f32(2).f32(3)         // channel 0
+	w.f32(4).f32(5).f32(6)         // channel 1
+
+	var c ComponentAnalog
+	if err := c.UnmarshalBinary(w.b); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	dev := c.AnalogDevices[0]
+	if dev.ID != 5 || dev.SampleNumber != 42 {
+		t.Errorf("id=%d sampleNumber=%d", dev.ID, dev.SampleNumber)
+	}
+	if len(dev.Channels) != 2 {
+		t.Fatalf("got %d channels, want 2", len(dev.Channels))
+	}
+	if dev.Channels[1].Samples[0].Value != 4 {
+		t.Errorf("channel 1 sample 0 = %v, want 4", dev.Channels[1].Samples[0].Value)
+	}
+}
+
+func TestComponentForcePlateSamples(t *testing.T) {
+	w := (&builder{}).u32(1)
+	w.u32(3).u32(2).u32(77) // plate 3, 2 samples, force number 77
+	for i := 0; i < 2; i++ {
+		base := float32(i * 10)
+		w.f32(base).f32(base + 1).f32(base + 2)
+		w.f32(base + 3).f32(base + 4).f32(base + 5)
+		w.f32(base + 6).f32(base + 7).f32(base + 8)
+	}
+
+	var c ComponentForce
+	if err := c.UnmarshalBinary(w.b); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	fp := c.ForcePlates[0]
+	if fp.ID != 3 || fp.Number != 77 || len(fp.Samples) != 2 {
+		t.Fatalf("plate = %+v", fp)
+	}
+	if fp.Samples[1].CenterOfPressure.Z != 18 {
+		t.Errorf("second sample CoP.Z = %v, want 18", fp.Samples[1].CenterOfPressure.Z)
+	}
+}
+
+func TestGazeVectorZeroSampleDeviceOmitsSampleNumber(t *testing.T) {
+	// A device reporting no samples writes only its 4 byte sample count, with
+	// no sample number field. Getting this stride wrong desynchronises every
+	// following device.
+	w := (&builder{}).u32(2)
+	w.u32(0) // device 0: no samples
+	w.u32(1).u32(99)
+	w.f32(1).f32(2).f32(3).f32(4).f32(5).f32(6)
+
+	var c ComponentGazeVector
+	if err := c.UnmarshalBinary(w.b); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(c.GazeVectors) != 2 {
+		t.Fatalf("got %d gaze vectors, want 2", len(c.GazeVectors))
+	}
+	if len(c.GazeVectors[0].Samples) != 0 {
+		t.Errorf("first device should have no samples")
+	}
+	if c.GazeVectors[1].SampleNumber != 99 || c.GazeVectors[1].Samples[0].PositionZ != 6 {
+		t.Errorf("second device = %+v", c.GazeVectors[1])
+	}
+}
+
+func TestEyeTrackerZeroSampleDeviceOmitsSampleNumber(t *testing.T) {
+	w := (&builder{}).u32(2)
+	w.u32(0)
+	w.u32(1).u32(7)
+	w.f32(2.5).f32(3.5)
+
+	var c ComponentEyeTracker
+	if err := c.UnmarshalBinary(w.b); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(c.EyeTrackers) != 2 {
+		t.Fatalf("got %d eye trackers, want 2", len(c.EyeTrackers))
+	}
+	if c.EyeTrackers[1].SampleNumber != 7 || c.EyeTrackers[1].Samples[0].RightPupilDiameter != 3.5 {
+		t.Errorf("second device = %+v", c.EyeTrackers[1])
+	}
+}
+
+// TestTruncatedPayloadsDoNotPanic feeds every parser a progressively truncated
+// version of a valid payload. Before the bounds-checked cursor these all
+// panicked with an index out of range, taking down the whole client process for
+// one malformed frame.
+func TestTruncatedPayloadsDoNotPanic(t *testing.T) {
+	valid := (&builder{}).u32(2).u16(1).u16(2).
+		f32(1).f32(2).f32(3).u32(4).f32(5).
+		f32(6).f32(7).f32(8).u32(9).f32(10).b
+
+	parsers := map[string]func() interface{ UnmarshalBinary([]byte) error }{
+		"3D":            func() interface{ UnmarshalBinary([]byte) error } { return &Component3D{} },
+		"3DRes":         func() interface{ UnmarshalBinary([]byte) error } { return &Component3DResidual{} },
+		"3DNoLabels":    func() interface{ UnmarshalBinary([]byte) error } { return &Component3DNoLabels{} },
+		"3DNoLabelsRes": func() interface{ UnmarshalBinary([]byte) error } { return &Component3DNoLabelsResidual{} },
+		"6D":            func() interface{ UnmarshalBinary([]byte) error } { return &Component6D{} },
+		"6DRes":         func() interface{ UnmarshalBinary([]byte) error } { return &Component6DResidual{} },
+		"6DEuler":       func() interface{ UnmarshalBinary([]byte) error } { return &Component6DEuler{} },
+		"6DEulerRes":    func() interface{ UnmarshalBinary([]byte) error } { return &Component6DEulerResidual{} },
+		"2D":            func() interface{ UnmarshalBinary([]byte) error } { return &Component2D{} },
+		"2DLin":         func() interface{ UnmarshalBinary([]byte) error } { return &Component2DLinearized{} },
+		"Analog":        func() interface{ UnmarshalBinary([]byte) error } { return &ComponentAnalog{} },
+		"AnalogSingle":  func() interface{ UnmarshalBinary([]byte) error } { return &ComponentAnalogSingle{} },
+		"Force":         func() interface{ UnmarshalBinary([]byte) error } { return &ComponentForce{} },
+		"ForceSingle":   func() interface{ UnmarshalBinary([]byte) error } { return &ComponentForceSingle{} },
+		"Image":         func() interface{ UnmarshalBinary([]byte) error } { return &ComponentImage{} },
+		"GazeVector":    func() interface{ UnmarshalBinary([]byte) error } { return &ComponentGazeVector{} },
+		"EyeTracker":    func() interface{ UnmarshalBinary([]byte) error } { return &ComponentEyeTracker{} },
+		"Timecode":      func() interface{ UnmarshalBinary([]byte) error } { return &ComponentTimecode{} },
+		"Skeleton":      func() interface{ UnmarshalBinary([]byte) error } { return &ComponentSkeleton{} },
+	}
+
+	for name, mk := range parsers {
+		t.Run(name, func(t *testing.T) {
+			for n := 0; n <= len(valid); n++ {
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							t.Fatalf("panic on %d byte payload: %v", n, r)
+						}
+					}()
+					// Errors are fine here; panics are not.
+					_ = mk().UnmarshalBinary(valid[:n])
+				}()
+			}
+		})
+	}
+}
+
+func TestCursorReportsShortReads(t *testing.T) {
+	c := newCursor([]byte{1, 2})
+	c.Uint32()
+	if !errors.Is(c.Err(), ErrShortPacket) {
+		t.Fatalf("got %v, want ErrShortPacket", c.Err())
+	}
+	// Once failed, further reads are inert rather than panicking.
+	if got := c.Uint32(); got != 0 {
+		t.Errorf("read after failure = %d, want 0", got)
+	}
+}
+
+func TestCursorBytesReturnsACopy(t *testing.T) {
+	// The receive buffer is reused between frames, so handing out a sub-slice
+	// would let the next frame silently rewrite a caller's data.
+	src := []byte{1, 2, 3, 4}
+	c := newCursor(src)
+	got := c.Bytes(4)
+	src[0] = 99
+	if got[0] != 1 {
+		t.Errorf("Bytes returned an alias into the source buffer")
+	}
+}
+
+func TestCameraStringFieldOrder(t *testing.T) {
+	// Regression: Status and Markers were passed to Sprintf in the wrong order,
+	// so every 2D dump printed the two fields swapped.
+	cam := Camera{Status: 3, Markers: []Marker2D{{X: 1, Y: 2}}}
+	got := cam.String()
+	want := "Status: 3 Markers2D: [[x:1 y:2 dx:0 dy:0]]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/packets/skeleton.go
+++ b/pkg/packets/skeleton.go
@@ -1,14 +1,14 @@
 package packets
 
-import (
-	"encoding/binary"
-	"fmt"
-)
+import "fmt"
 
 type Rotation struct {
 	X, Y, Z, W float32
 }
 
+// Segment is one skeleton segment. Position and rotation are relative to the
+// parent segment unless the stream was requested with the "global" option, in
+// which case they are in the global coordinate system.
 type Segment struct {
 	ID       uint32
 	Position Point
@@ -27,6 +27,8 @@ type Skeleton struct {
 	Segments []Segment
 }
 
+func (s Skeleton) String() string { return fmt.Sprintf("%v", s.Segments) }
+
 type ComponentSkeleton struct {
 	Skeletons []Skeleton
 }
@@ -35,29 +37,34 @@ func (c ComponentSkeleton) String() string {
 	return fmt.Sprintf("Skeletons: %v", c.Skeletons)
 }
 
+// segmentBytes is id + 3 position floats + 4 rotation floats.
+const segmentBytes = 32
+
 func (c *ComponentSkeleton) UnmarshalBinary(data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
-	numberOfSkeletons := binary.LittleEndian.Uint32(data[0:4])
-	pos := 4
-	c.Skeletons = make([]Skeleton, 0, numberOfSkeletons)
-	for m := uint32(0); m < numberOfSkeletons; m++ {
-		segments := binary.LittleEndian.Uint32(data[pos : pos+4])
-		s := make([]Segment, segments)
-		for i := uint32(0); i < segments; i++ {
-			s[i].ID = binary.LittleEndian.Uint32(data[pos+4 : pos+8])
-			s[i].Position.X = Float32frombytes(data[pos+8 : pos+12])
-			s[i].Position.Y = Float32frombytes(data[pos+12 : pos+16])
-			s[i].Position.Z = Float32frombytes(data[pos+16 : pos+20])
-			s[i].Rotation.X = Float32frombytes(data[pos+20 : pos+24])
-			s[i].Rotation.Y = Float32frombytes(data[pos+24 : pos+28])
-			s[i].Rotation.Z = Float32frombytes(data[pos+28 : pos+32])
-			s[i].Rotation.W = Float32frombytes(data[pos+32 : pos+36])
-			pos += 32
-		}
-		c.Skeletons = append(c.Skeletons, Skeleton{Segments: s})
-		pos += 4
+	cur := newCursor(data)
+	skeletonCount := cur.Uint32()
+	if !cur.checkCount(skeletonCount, 4, "skeleton") {
+		return cur.Err()
 	}
-	return nil
+
+	c.Skeletons = make([]Skeleton, 0, skeletonCount)
+	for i := uint32(0); i < skeletonCount; i++ {
+		segmentCount := cur.Uint32()
+		if !cur.checkCount(segmentCount, segmentBytes, "skeleton segment") {
+			return cur.Err()
+		}
+		segments := make([]Segment, segmentCount)
+		for s := uint32(0); s < segmentCount; s++ {
+			segments[s].ID = cur.Uint32()
+			segments[s].Position = cur.Point()
+			segments[s].Rotation = Rotation{
+				X: cur.Float32(), Y: cur.Float32(), Z: cur.Float32(), W: cur.Float32(),
+			}
+		}
+		c.Skeletons = append(c.Skeletons, Skeleton{Segments: segments})
+	}
+	return cur.Err()
 }

--- a/pkg/packets/timecode.go
+++ b/pkg/packets/timecode.go
@@ -1,9 +1,6 @@
 package packets
 
-import (
-	"encoding/binary"
-	"fmt"
-)
+import "fmt"
 
 //go:generate stringer -type TimecodeType -trimprefix TimecodeType
 type TimecodeType uint32
@@ -19,44 +16,59 @@ type IrigTime struct {
 }
 
 func (i *IrigTime) Convert(high, low uint32) {
-	i.Year = 0x7f & high
+	i.Year = 0x7F & high
 	i.Day = 0x1FF & (high >> 7)
-	i.Hour = 0x1f & low
+	i.Hour = 0x1F & low
 	i.Minute = 0x3F & (low >> 5)
 	i.Second = 0x3F & (low >> 11)
 	i.Tenth = 0xF & (low >> 17)
-}
-
-type SmpteTime struct {
-	Hour, Minute, Second, Frame uint32
-}
-
-func (i *SmpteTime) Convert(_, low uint32) {
-	i.Hour = 0x1f & low
-	i.Minute = 0x3F & (low >> 5)
-	i.Second = 0x3F & (low >> 11)
-	i.Frame = 0x1F & (low >> 17)
-}
-
-type CameraTime uint64
-
-func (i *CameraTime) Convert(high, low uint32) {
-	*i = CameraTime((uint64(high) << uint64(32)) | uint64(low))
-}
-
-func (i *SmpteTime) String() string {
-	return fmt.Sprintf("%02d:%02d:%02d:%02d", i.Hour, i.Minute, i.Second, i.Frame)
 }
 
 func (i *IrigTime) String() string {
 	return fmt.Sprintf("%02d:%03d:%02d:%02d:%02d.%d", i.Year, i.Day, i.Hour, i.Minute, i.Second, i.Tenth)
 }
 
+// SmpteTime is an SMPTE timecode. SubFrame counts camera frames within a single
+// timecode frame and is what makes the timecode usable above the timecode
+// frequency; it was previously dropped on the floor during decoding.
+type SmpteTime struct {
+	Hour, Minute, Second, Frame, SubFrame uint32
+}
+
+func (i *SmpteTime) Convert(_, low uint32) {
+	i.Hour = 0x1F & low
+	i.Minute = 0x3F & (low >> 5)
+	i.Second = 0x3F & (low >> 11)
+	i.Frame = 0x1F & (low >> 17)
+	i.SubFrame = 0x1FF & (low >> 22)
+}
+
+func (i *SmpteTime) String() string {
+	return fmt.Sprintf("%02d:%02d:%02d:%02d", i.Hour, i.Minute, i.Second, i.Frame)
+}
+
+// NormalizedSubFrame expresses SubFrame as a fraction of one timecode frame,
+// given the camera capture frequency and the timecode frequency. It mirrors
+// CRTProtocol::SMPTENormalizedSubFrame in the C++ SDK.
+func (i *SmpteTime) NormalizedSubFrame(captureFrequency, timestampFrequency uint32) float64 {
+	if captureFrequency == 0 || timestampFrequency == 0 || captureFrequency < timestampFrequency {
+		return 0
+	}
+	subFramesPerFrame := captureFrequency / timestampFrequency
+	return float64(i.SubFrame) / float64(subFramesPerFrame)
+}
+
+type CameraTime uint64
+
+func (i *CameraTime) Convert(high, low uint32) {
+	*i = CameraTime((uint64(high) << 32) | uint64(low))
+}
+
 func (i *CameraTime) String() string {
 	const ticksPerSecond = 10000000
-	seconds := (*i / ticksPerSecond)
-	nanoseconds := ((*i % ticksPerSecond) * (1000000000 / ticksPerSecond))
-	return fmt.Sprintf("%v.%v", seconds, nanoseconds)
+	seconds := *i / ticksPerSecond
+	nanoseconds := (*i % ticksPerSecond) * (1000000000 / ticksPerSecond)
+	return fmt.Sprintf("%v.%09v", seconds, nanoseconds)
 }
 
 type Timecode struct {
@@ -86,24 +98,39 @@ func (c ComponentTimecode) String() string {
 	return fmt.Sprintf("Timecodes: %v", c.Timecodes)
 }
 
+// timecodeEntryBytes is type + high word + low word.
+const timecodeEntryBytes = 12
+
+// UnmarshalBinary decodes the timecode component.
+//
+// The previous implementation read every entry from the same three fixed
+// offsets, so a stream carrying more than one timecode reported the first one
+// repeated N times. Each entry is a fixed 12 bytes and the cursor advances
+// through them.
 func (c *ComponentTimecode) UnmarshalBinary(data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
-	numberOfTimecodes := binary.LittleEndian.Uint32(data[0:4])
-	c.Timecodes = make([]Timecode, numberOfTimecodes)
-	for i := uint32(0); i < numberOfTimecodes; i++ {
-		c.Timecodes[i].Type = TimecodeType(binary.LittleEndian.Uint32(data[4:8]))
-		high := binary.LittleEndian.Uint32(data[8:12])
-		low := binary.LittleEndian.Uint32(data[12:16])
-		switch c.Timecodes[i].Type {
+	cur := newCursor(data)
+	count := cur.Uint32()
+	if !cur.checkCount(count, timecodeEntryBytes, "timecode") {
+		return cur.Err()
+	}
+
+	c.Timecodes = make([]Timecode, count)
+	for i := uint32(0); i < count; i++ {
+		tc := &c.Timecodes[i]
+		tc.Type = TimecodeType(cur.Uint32())
+		high := cur.Uint32()
+		low := cur.Uint32()
+		switch tc.Type {
 		case TimecodeTypeSMPTE:
-			c.Timecodes[i].Smpte.Convert(high, low)
+			tc.Smpte.Convert(high, low)
 		case TimecodeTypeIRIG:
-			c.Timecodes[i].Irig.Convert(high, low)
+			tc.Irig.Convert(high, low)
 		case TimecodeTypeCameraTime:
-			c.Timecodes[i].CameraTime.Convert(high, low)
+			tc.CameraTime.Convert(high, low)
 		}
 	}
-	return nil
+	return cur.Err()
 }

--- a/pkg/packets/timecode.go
+++ b/pkg/packets/timecode.go
@@ -1,6 +1,9 @@
 package packets
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 //go:generate stringer -type TimecodeType -trimprefix TimecodeType
 type TimecodeType uint32
@@ -58,7 +61,13 @@ func (i *SmpteTime) NormalizedSubFrame(captureFrequency, timestampFrequency uint
 	return float64(i.SubFrame) / float64(subFramesPerFrame)
 }
 
+// CameraTime is camera time in 100 nanosecond ticks.
 type CameraTime uint64
+
+// Duration converts the tick count to a time.Duration.
+func (i CameraTime) Duration() time.Duration {
+	return time.Duration(i) * 100 * time.Nanosecond
+}
 
 func (i *CameraTime) Convert(high, low uint32) {
 	*i = CameraTime((uint64(high) << 32) | uint64(low))
@@ -76,6 +85,10 @@ type Timecode struct {
 	Irig       IrigTime
 	Smpte      SmpteTime
 	CameraTime CameraTime
+
+	// High and Low hold the raw words for a timecode type this SDK does not
+	// recognise, so a caller that does know the format can still decode it.
+	High, Low uint32
 }
 
 func (c Timecode) String() string {
@@ -87,7 +100,7 @@ func (c Timecode) String() string {
 	case TimecodeTypeCameraTime:
 		return c.CameraTime.String()
 	}
-	return "unknown timecode"
+	return fmt.Sprintf("unknown timecode type %d (%#08x %#08x)", int(c.Type), c.High, c.Low)
 }
 
 type ComponentTimecode struct {
@@ -130,6 +143,8 @@ func (c *ComponentTimecode) UnmarshalBinary(data []byte) error {
 			tc.Irig.Convert(high, low)
 		case TimecodeTypeCameraTime:
 			tc.CameraTime.Convert(high, low)
+		default:
+			tc.High, tc.Low = high, low
 		}
 	}
 	return cur.Err()

--- a/pkg/packets/timecode.go
+++ b/pkg/packets/timecode.go
@@ -87,7 +87,7 @@ type Timecode struct {
 	CameraTime CameraTime
 
 	// High and Low hold the raw words for a timecode type this SDK does not
-	// recognise, so a caller that does know the format can still decode it.
+	// recognize, so a caller that does know the format can still decode it.
 	High, Low uint32
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -35,121 +35,423 @@ const (
 	ComponentTypeEyeTracker
 )
 
+// Protocol version constants.
+//
+// DefaultMajorVersion/DefaultMinorVersion track the newest RT protocol version
+// this SDK knows about, matching MAJOR_VERSION/MINOR_VERSION in the C++ SDK's
+// RTPacket.h. MinSupportedMinorVersion is the oldest version Connect will
+// negotiate down to.
+const (
+	DefaultMajorVersion      = 1
+	DefaultMinorVersion      = 28
+	MinSupportedMinorVersion = 22
+)
+
+// Port constants. QTM listens on base+1 for little-endian clients and base+2
+// for big-endian clients; the base port itself speaks protocol version 1.0,
+// which this SDK does not implement.
+const (
+	DefaultBasePort         = 22222
+	DefaultLittleEndianPort = 22223
+	DefaultBigEndianPort    = 22224
+)
+
+// Default timeouts.
+const (
+	DefaultReadTimeout    = 1 * time.Second
+	DefaultConnectTimeout = 5 * time.Second
+	// DefaultCommandTimeout applies to commands that wait for a response.
+	DefaultCommandTimeout = 5 * time.Second
+	// DefaultCalibrationTimeout matches cWaitForCalibrationTimeout in the C++
+	// SDK. A camera calibration routinely takes minutes; the previous
+	// hard-coded one second read deadline made Calibrate unusable.
+	DefaultCalibrationTimeout = 10 * time.Minute
+	// DefaultFileTimeout is how long to wait for a C3D or QTM file transfer.
+	DefaultFileTimeout = 30 * time.Second
+)
+
+// DefaultMaxPacketSize caps how large a single packet may claim to be. QTM
+// image and file packets are legitimately large, but an unbounded size field
+// read straight off the wire is an easy way to make a client allocate itself to
+// death.
+const DefaultMaxPacketSize = 512 << 20 // 512 MiB
+
+// Errors returned by the protocol. They are sentinels so callers can use
+// errors.Is rather than matching on message text.
+var (
+	// ErrTimeout is returned when no packet arrived within the read timeout.
+	ErrTimeout = errors.New("qualisys: receive timeout")
+	// ErrNotConnected is returned by any operation that needs a live socket.
+	ErrNotConnected = errors.New("qualisys: not connected")
+	// ErrTruncated means a packet header was read but the body never fully
+	// arrived. The stream is desynchronised at this point and the connection
+	// must be re-established.
+	ErrTruncated = errors.New("qualisys: packet truncated")
+	// ErrVersionNotSupported means QTM rejected every protocol version this
+	// SDK is willing to speak.
+	ErrVersionNotSupported = errors.New("qualisys: no mutually supported protocol version")
+)
+
+const packetHeaderSize = 8
+
+// Protocol is a client for the QTM real time protocol. It is not safe for
+// concurrent use by multiple goroutines.
 type Protocol struct {
-	conn     net.Conn
-	buffer   []byte
+	conn    net.Conn
+	udpConn *net.UDPConn
+	buffer  []byte
+
 	ip       string
 	basePort int
+
+	// Negotiated protocol version, valid after a successful Connect.
+	majorVersion int
+	minorVersion int
+
+	// Requested version and whether to fall back to older versions.
+	wantMajor        int
+	wantMinor        int
+	negotiateVersion bool
+
+	bigEndian bool
+	order     binary.ByteOrder
+
+	readTimeout    time.Duration
+	connectTimeout time.Duration
+	maxPacketSize  int
+
+	// lastEvent tracks the most recent event packet seen, including events
+	// swallowed while waiting for a command response.
+	lastEvent EventType
+	state     EventType
 }
 
-const DefaultLittleEndianPort = 22223
+// Option configures a Protocol. Options are applied in NewProtocol.
+type Option func(*Protocol)
 
-func NewProtocol(ip string, basePort int) *Protocol {
-	const startBufferSize int = 4096
-	rt := new(Protocol)
-	rt.buffer = make([]byte, startBufferSize)
-	rt.ip = ip
-	rt.basePort = basePort
+// WithVersion requests a specific protocol version instead of the SDK default.
+func WithVersion(major, minor int) Option {
+	return func(p *Protocol) {
+		p.wantMajor = major
+		p.wantMinor = minor
+	}
+}
+
+// WithoutVersionNegotiation disables falling back to older protocol versions.
+// Connect then fails outright if QTM will not accept the requested version.
+func WithoutVersionNegotiation() Option {
+	return func(p *Protocol) { p.negotiateVersion = false }
+}
+
+// WithBigEndian selects the big-endian port and byte order. Most callers should
+// not need this; it exists for parity with the C++ SDK.
+func WithBigEndian() Option {
+	return func(p *Protocol) {
+		p.bigEndian = true
+		p.order = binary.BigEndian
+	}
+}
+
+// WithReadTimeout sets how long Receive waits for a packet to begin arriving.
+func WithReadTimeout(d time.Duration) Option {
+	return func(p *Protocol) { p.readTimeout = d }
+}
+
+// WithConnectTimeout sets the TCP dial timeout.
+func WithConnectTimeout(d time.Duration) Option {
+	return func(p *Protocol) { p.connectTimeout = d }
+}
+
+// WithMaxPacketSize caps the accepted packet size. Set this below the default
+// if the client runs somewhere memory constrained.
+func WithMaxPacketSize(n int) Option {
+	return func(p *Protocol) { p.maxPacketSize = n }
+}
+
+// NewProtocol creates a client for the QTM instance at ip. basePort is QTM's
+// base port, normally DefaultBasePort; the correct endian-specific port is
+// derived from it.
+func NewProtocol(ip string, basePort int, opts ...Option) *Protocol {
+	const startBufferSize = 4096
+	rt := &Protocol{
+		buffer:           make([]byte, startBufferSize),
+		ip:               ip,
+		basePort:         basePort,
+		wantMajor:        DefaultMajorVersion,
+		wantMinor:        DefaultMinorVersion,
+		negotiateVersion: true,
+		order:            binary.LittleEndian,
+		readTimeout:      DefaultReadTimeout,
+		connectTimeout:   DefaultConnectTimeout,
+		maxPacketSize:    DefaultMaxPacketSize,
+		lastEvent:        EventTypeNone,
+		state:            EventTypeNone,
+	}
+	for _, opt := range opts {
+		opt(rt)
+	}
 	return rt
 }
 
+// port returns the TCP port to connect to for the configured byte order.
+func (rt *Protocol) port() int {
+	if rt.bigEndian {
+		return rt.basePort + 2
+	}
+	return rt.basePort + 1
+}
+
+// versionCandidates builds the ordered list of protocol versions to try.
+//
+// This mirrors RTVersion::VersionList in the C++ SDK: the requested version
+// first, then progressively older versions, skipping any that are newer than or
+// equal to what was requested. The ladder stops at MinSupportedMinorVersion so
+// that connecting to a QTM older than the documented floor fails cleanly
+// instead of silently negotiating something this SDK cannot parse.
+func (rt *Protocol) versionCandidates() [][2]int {
+	candidates := [][2]int{{rt.wantMajor, rt.wantMinor}}
+	if !rt.negotiateVersion {
+		return candidates
+	}
+	for minor := DefaultMinorVersion; minor >= MinSupportedMinorVersion; minor-- {
+		if rt.wantMajor == DefaultMajorVersion && minor >= rt.wantMinor {
+			continue
+		}
+		candidates = append(candidates, [2]int{DefaultMajorVersion, minor})
+	}
+	return candidates
+}
+
+// Connect opens the TCP connection, reads QTM's welcome message and negotiates
+// a protocol version.
+//
+// On any failure the socket is closed before returning, so IsConnected reports
+// false and the Protocol can be reused for a retry. The previous implementation
+// left a half-open connection behind on a failed handshake, so a caller looping
+// on "if !IsConnected() { Connect() }" would spin forever against an
+// incompatible QTM.
 func (rt *Protocol) Connect() error {
 	if rt.IsConnected() {
 		rt.Disconnect()
 	}
-	portLittleEndian := rt.basePort + 1
-	ipAndPort := rt.ip + ":" + strconv.Itoa(portLittleEndian)
-	raddr, err := net.ResolveTCPAddr("tcp", ipAndPort)
+
+	addr := net.JoinHostPort(rt.ip, strconv.Itoa(rt.port()))
+	conn, err := net.DialTimeout("tcp", addr, rt.connectTimeout)
 	if err != nil {
-		return fmt.Errorf("connect: resolvetcpaddr: %w", err)
-	}
-	conn, err := net.DialTCP("tcp", nil, raddr)
-	if err != nil {
-		return fmt.Errorf("connect: dial: %w", err)
+		return fmt.Errorf("connect: dial %s: %w", addr, err)
 	}
 	rt.conn = conn
-	p, err := rt.Receive()
+
+	p, err := rt.ReceiveTimeout(rt.connectTimeout)
 	if err != nil {
-		return fmt.Errorf("connect: receive: %w", err)
+		rt.Disconnect()
+		return fmt.Errorf("connect: welcome: %w", err)
 	}
-	const qtmConnectedResponse string = "QTM RT Interface connected"
+	const qtmConnectedResponse = "QTM RT Interface connected"
 	if p.CommandResponse != qtmConnectedResponse {
-		return fmt.Errorf("connect: unexpected response (%s)", p.CommandResponse)
+		rt.Disconnect()
+		return fmt.Errorf("connect: unexpected welcome message (%q)", p.CommandResponse)
 	}
-	const (
-		majorVer = 1
-		minorVer = 22
-	)
-	err = rt.SetVersion(majorVer, minorVer)
-	return err
+
+	var lastErr error
+	for _, v := range rt.versionCandidates() {
+		if err := rt.SetVersion(v[0], v[1]); err != nil {
+			lastErr = err
+			continue
+		}
+		// Prime the cached state the same way the C++ SDK does after a
+		// successful handshake. A failure here is not fatal.
+		_, _ = rt.GetState()
+		return nil
+	}
+
+	rt.Disconnect()
+	if lastErr == nil {
+		lastErr = ErrVersionNotSupported
+	}
+	return fmt.Errorf("connect: %w (tried %d.%d down to %d.%d): %v",
+		ErrVersionNotSupported, rt.wantMajor, rt.wantMinor,
+		DefaultMajorVersion, MinSupportedMinorVersion, lastErr)
 }
 
+// IsConnected reports whether a TCP connection is currently open.
 func (rt *Protocol) IsConnected() bool {
 	return rt.conn != nil
 }
 
+// Disconnect closes the TCP connection and any UDP stream socket.
 func (rt *Protocol) Disconnect() {
-	if !rt.IsConnected() {
+	if rt.udpConn != nil {
+		rt.udpConn.Close()
+		rt.udpConn = nil
+	}
+	if rt.conn == nil {
 		return
 	}
 	rt.conn.Close()
 	rt.conn = nil
+	rt.majorVersion = 0
+	rt.minorVersion = 0
 }
 
+// Version returns the negotiated protocol version. It is only meaningful after
+// a successful Connect.
+func (rt *Protocol) Version() (major, minor int) {
+	return rt.majorVersion, rt.minorVersion
+}
+
+// ParametersElementName returns the root element name used by the negotiated
+// protocol version, for example "QTM_Parameters_Ver_1.28".
+//
+// Callers editing settings XML should use this rather than hard-coding a
+// version, since the element name changes with every protocol revision.
+func (rt *Protocol) ParametersElementName() string {
+	return fmt.Sprintf("QTM_Parameters_Ver_%d.%d", rt.majorVersion, rt.minorVersion)
+}
+
+// State returns the most recent event QTM reported, including events observed
+// while waiting for a command response.
+func (rt *Protocol) State() EventType {
+	return rt.state
+}
+
+// setReadDeadline applies d, or clears the deadline when d is zero or negative.
+func (rt *Protocol) setReadDeadline(d time.Duration) error {
+	if d <= 0 {
+		return rt.conn.SetReadDeadline(time.Time{})
+	}
+	return rt.conn.SetReadDeadline(time.Now().Add(d))
+}
+
+func isTimeout(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+// Receive reads the next packet using the configured read timeout.
+//
+// When no data arrives within the timeout it returns a PacketTypeNoMoreData
+// packet with a nil error, which is the contract the bundled examples poll on.
+// A packet is always returned non-nil, even alongside an error, so callers that
+// inspect the packet before checking the error do not panic on a nil pointer.
 func (rt *Protocol) Receive() (*Packet, error) {
-	for i := range rt.buffer {
-		rt.buffer[i] = 0
+	return rt.ReceiveTimeout(rt.readTimeout)
+}
+
+// ReceiveTimeout reads the next packet, waiting at most d for it to start
+// arriving. A non-positive d blocks indefinitely.
+func (rt *Protocol) ReceiveTimeout(d time.Duration) (*Packet, error) {
+	if !rt.IsConnected() {
+		return &Packet{Type: PacketTypeNone}, ErrNotConnected
 	}
-	if err := rt.conn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
-		return nil, fmt.Errorf("receive: setreaddeadline: %w", err)
+
+	if err := rt.setReadDeadline(d); err != nil {
+		return &Packet{Type: PacketTypeNone}, fmt.Errorf("receive: set deadline: %w", err)
 	}
-	const packetHeaderSize = 8
-	packetSize, err := rt.conn.Read(rt.buffer[0:packetHeaderSize])
-	if err != nil {
-		var netError net.Error
-		if errors.As(err, &netError) && netError.Timeout() {
+
+	// Read the fixed 8 byte header. io.ReadFull matters here: TCP is free to
+	// deliver fewer than 8 bytes on the first read, and the previous code
+	// treated any short read as a fatal "packet too small for header" error.
+	if _, err := io.ReadFull(rt.conn, rt.buffer[:packetHeaderSize]); err != nil {
+		if isTimeout(err) {
 			return &Packet{Type: PacketTypeNoMoreData}, nil
 		}
-		return nil, fmt.Errorf("receive: read %w", err)
-	}
-	if packetSize < packetHeaderSize {
-		return nil, fmt.Errorf("receive: packet to small for header")
-	}
-	var p Packet
-	p.Size = int(binary.LittleEndian.Uint32(rt.buffer[0:4]))
-	p.Type = PacketType(binary.LittleEndian.Uint32(rt.buffer[4:8]))
-	if len(rt.buffer) < p.Size {
-		rt.buffer = append(rt.buffer, make([]byte, p.Size)...)
-	}
-	if packetSize >= p.Size {
-		return &p, nil
-	}
-	if err := rt.conn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
-		return nil, fmt.Errorf("receive: setreaddeadline: %w", err)
-	}
-	pos := packetSize
-	for {
-		n, err := rt.conn.Read(rt.buffer[pos:p.Size])
-		if err != nil {
-			var netError net.Error
-			if errors.As(err, &netError) && netError.Timeout() {
-				return &Packet{Type: PacketTypeNoMoreData}, nil
-			}
-			if !errors.Is(err, io.EOF) {
-				return nil, fmt.Errorf("receive: read %w", err)
-			}
-			break
+		if errors.Is(err, io.EOF) {
+			return &Packet{Type: PacketTypeNone}, fmt.Errorf("receive: connection closed: %w", err)
 		}
-		pos += n
-		if pos >= p.Size {
-			break
+		return &Packet{Type: PacketTypeNone}, fmt.Errorf("receive: read header: %w", err)
+	}
+
+	size := int(rt.order.Uint32(rt.buffer[0:4]))
+	ptype := PacketType(rt.order.Uint32(rt.buffer[4:8]))
+
+	if size < packetHeaderSize {
+		return &Packet{Type: PacketTypeNone},
+			fmt.Errorf("receive: invalid packet size %d", size)
+	}
+	if size > rt.maxPacketSize {
+		return &Packet{Type: PacketTypeNone},
+			fmt.Errorf("receive: packet size %d exceeds limit %d", size, rt.maxPacketSize)
+	}
+
+	// A header-only packet carries no payload; PacketTypeNoMoreData arrives
+	// this way.
+	if size == packetHeaderSize {
+		return &Packet{Size: size, Type: ptype, order: rt.order}, nil
+	}
+
+	if cap(rt.buffer) < size {
+		rt.buffer = make([]byte, size)
+	}
+	rt.buffer = rt.buffer[:size]
+
+	// Once the header is consumed the rest of the packet must arrive. A
+	// timeout here means a desynchronised stream, not "no more data" --
+	// reporting it as the latter, as the old code did, left the remaining
+	// bytes in the socket to be misread as the next packet header.
+	if err := rt.setReadDeadline(rt.readTimeout); err != nil {
+		return &Packet{Type: PacketTypeNone}, fmt.Errorf("receive: set deadline: %w", err)
+	}
+	if _, err := io.ReadFull(rt.conn, rt.buffer[packetHeaderSize:size]); err != nil {
+		if isTimeout(err) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+			return &Packet{Type: PacketTypeNone},
+				fmt.Errorf("receive: %w: expected %d bytes: %v", ErrTruncated, size, err)
+		}
+		return &Packet{Type: PacketTypeNone}, fmt.Errorf("receive: read body: %w", err)
+	}
+
+	p := &Packet{order: rt.order}
+	if err := p.UnmarshalBinary(rt.buffer[:size]); err != nil {
+		return &Packet{Type: PacketTypeNone}, fmt.Errorf("receive: unmarshal: %w", err)
+	}
+
+	if p.Type == PacketTypeEvent {
+		rt.lastEvent = p.Event
+		// Camera settings changes are notifications rather than state
+		// transitions, matching the C++ SDK's handling.
+		if p.Event != EventTypeCameraSettingsChanged {
+			rt.state = p.Event
 		}
 	}
-	if err = p.UnmarshalBinary(rt.buffer[0:p.Size]); err != nil {
-		return nil, fmt.Errorf("receive: unmarshalbinary %w", err)
-	}
+
 	if p.Type == PacketTypeError {
-		return &p, fmt.Errorf("receive: error packet returned (%s)", p.ErrorResponse)
+		return p, fmt.Errorf("receive: error packet returned (%s)", p.ErrorResponse)
 	}
-	return &p, nil
+	return p, nil
+}
+
+// receiveSkippingEvents reads until a non-event packet arrives or the deadline
+// passes.
+//
+// QTM pushes events asynchronously, so a command response can be preceded by
+// any number of event packets. The previous implementation treated whatever
+// packet arrived first as the response, which made commands spuriously fail
+// whenever an event happened to be in flight -- for example, TakeControl issued
+// right after a capture started.
+func (rt *Protocol) receiveSkippingEvents(timeout time.Duration) (*Packet, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		var wait time.Duration
+		if timeout > 0 {
+			wait = time.Until(deadline)
+			if wait <= 0 {
+				return &Packet{Type: PacketTypeNone}, ErrTimeout
+			}
+		}
+		p, err := rt.ReceiveTimeout(wait)
+		if err != nil {
+			return p, err
+		}
+		switch p.Type {
+		case PacketTypeEvent:
+			continue
+		case PacketTypeNoMoreData:
+			if timeout > 0 && !time.Now().Before(deadline) {
+				return p, ErrTimeout
+			}
+			continue
+		default:
+			return p, nil
+		}
+	}
 }

--- a/protocol.go
+++ b/protocol.go
@@ -309,6 +309,14 @@ func (rt *Protocol) ParametersElementName() string {
 	return fmt.Sprintf("QTM_Parameters_Ver_%d.%d", rt.majorVersion, rt.minorVersion)
 }
 
+// LocalAddr returns the local address of the TCP connection.
+func (rt *Protocol) LocalAddr() net.Addr {
+	if rt.conn == nil {
+		return nil
+	}
+	return rt.conn.LocalAddr()
+}
+
 // State returns the most recent event QTM reported, including events observed
 // while waiting for a command response.
 func (rt *Protocol) State() EventType {
@@ -326,6 +334,12 @@ func (rt *Protocol) setReadDeadline(d time.Duration) error {
 func isTimeout(err error) bool {
 	var netErr net.Error
 	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+// IsTimeout reports whether err came from an operation timing out, whether that
+// was ErrTimeout from a command or an underlying socket deadline.
+func IsTimeout(err error) bool {
+	return errors.Is(err, ErrTimeout) || isTimeout(err)
 }
 
 // Receive reads the next packet using the configured read timeout.

--- a/protocol.go
+++ b/protocol.go
@@ -101,6 +101,12 @@ type Protocol struct {
 	udpConn *net.UDPConn
 	buffer  []byte
 
+	// udpBuffer is the receive buffer for the UDP data path. It is deliberately
+	// separate from buffer: commands keep flowing on TCP while data frames
+	// arrive over UDP, so the two paths are commonly driven from different
+	// goroutines and must not share a scratch buffer.
+	udpBuffer []byte
+
 	ip       string
 	basePort int
 

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -1,0 +1,542 @@
+package qualisys
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeQTM is a minimal stand-in for a QTM RT server. Handler is invoked for
+// each command string the client sends and returns raw packets to write back.
+type fakeQTM struct {
+	t        *testing.T
+	listener net.Listener
+
+	mu       sync.Mutex
+	commands []string
+
+	// welcome is sent as soon as a client connects.
+	welcome []byte
+	// handler produces the reply for a command. A nil reply sends nothing.
+	handler func(cmd string) []byte
+	// onConn, if set, takes over the connection entirely after the welcome.
+	onConn func(conn net.Conn)
+}
+
+func encodePacket(t PacketType, payload []byte) []byte {
+	size := packetHeaderSize + len(payload)
+	b := make([]byte, size)
+	binary.LittleEndian.PutUint32(b[0:4], uint32(size))
+	binary.LittleEndian.PutUint32(b[4:8], uint32(t))
+	copy(b[packetHeaderSize:], payload)
+	return b
+}
+
+func commandPacket(s string) []byte  { return encodePacket(PacketTypeCommand, append([]byte(s), 0)) }
+func errorPacket(s string) []byte    { return encodePacket(PacketTypeError, append([]byte(s), 0)) }
+func xmlPacket(s string) []byte      { return encodePacket(PacketTypeXML, append([]byte(s), 0)) }
+func eventPacket(e EventType) []byte { return encodePacket(PacketTypeEvent, []byte{byte(e)}) }
+
+func newFakeQTM(t *testing.T) *fakeQTM {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	f := &fakeQTM{
+		t:        t,
+		listener: l,
+		welcome:  commandPacket("QTM RT Interface connected"),
+	}
+	t.Cleanup(func() { l.Close() })
+	return f
+}
+
+// start begins accepting connections. It is separate from newFakeQTM so a test
+// can finish configuring the handler before any goroutine reads those fields.
+func (f *fakeQTM) start() {
+	go f.serve()
+}
+
+// basePort returns the value to pass to NewProtocol. The client connects to
+// basePort+1, so the base is one below the port actually being listened on.
+func (f *fakeQTM) basePort() int {
+	return f.listener.Addr().(*net.TCPAddr).Port - 1
+}
+
+func (f *fakeQTM) serve() {
+	for {
+		conn, err := f.listener.Accept()
+		if err != nil {
+			return
+		}
+		go f.handle(conn)
+	}
+}
+
+func (f *fakeQTM) handle(conn net.Conn) {
+	defer conn.Close()
+	if len(f.welcome) > 0 {
+		if _, err := conn.Write(f.welcome); err != nil {
+			return
+		}
+	}
+	if f.onConn != nil {
+		f.onConn(conn)
+		return
+	}
+	header := make([]byte, packetHeaderSize)
+	for {
+		if _, err := io.ReadFull(conn, header); err != nil {
+			return
+		}
+		size := int(binary.LittleEndian.Uint32(header[0:4]))
+		if size < packetHeaderSize {
+			return
+		}
+		body := make([]byte, size-packetHeaderSize)
+		if _, err := io.ReadFull(conn, body); err != nil {
+			return
+		}
+		cmd := strings.TrimRight(string(body), "\x00")
+
+		f.mu.Lock()
+		f.commands = append(f.commands, cmd)
+		f.mu.Unlock()
+
+		if f.handler == nil {
+			continue
+		}
+		if reply := f.handler(cmd); reply != nil {
+			if _, err := conn.Write(reply); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (f *fakeQTM) sentCommands() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.commands))
+	copy(out, f.commands)
+	return out
+}
+
+// waitForCommand polls until cmd has been received or the deadline passes.
+// Fire-and-forget commands such as StreamFrames send no reply, so the test has
+// no response to synchronise on.
+func (f *fakeQTM) waitForCommand(cmd string, within time.Duration) bool {
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		for _, c := range f.sentCommands() {
+			if c == cmd {
+				return true
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+// acceptVersion builds a handler that accepts one specific protocol version and
+// rejects every other, mimicking a QTM older than this SDK.
+func acceptVersion(major, minor int) func(string) []byte {
+	want := "Version " + itoa(major) + "." + itoa(minor)
+	return func(cmd string) []byte {
+		switch {
+		case cmd == want:
+			return commandPacket("Version set to " + itoa(major) + "." + itoa(minor))
+		case strings.HasPrefix(cmd, "Version "):
+			return errorPacket("Version not supported")
+		case cmd == "GetState":
+			return eventPacket(EventTypeConnected)
+		}
+		return nil
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}
+
+func TestConnectNegotiatesDownToOlderVersion(t *testing.T) {
+	// QTM only speaks 1.25. The SDK should walk down from its 1.28 default and
+	// settle there, which is exactly what the previous hard-coded 1.22
+	// handshake could not do.
+	f := newFakeQTM(t)
+	f.handler = acceptVersion(1, 25)
+	f.start()
+
+	rt := NewProtocol("127.0.0.1", f.basePort())
+	if err := rt.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer rt.Disconnect()
+
+	major, minor := rt.Version()
+	if major != 1 || minor != 25 {
+		t.Errorf("negotiated %d.%d, want 1.25", major, minor)
+	}
+
+	cmds := f.sentCommands()
+	if len(cmds) == 0 || cmds[0] != "Version 1.28" {
+		t.Errorf("first command = %q, want the newest version tried first", cmds)
+	}
+}
+
+func TestConnectPrefersNewestAcceptedVersion(t *testing.T) {
+	f := newFakeQTM(t)
+	f.handler = acceptVersion(DefaultMajorVersion, DefaultMinorVersion)
+	f.start()
+
+	rt := NewProtocol("127.0.0.1", f.basePort())
+	if err := rt.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer rt.Disconnect()
+
+	major, minor := rt.Version()
+	if major != DefaultMajorVersion || minor != DefaultMinorVersion {
+		t.Errorf("negotiated %d.%d, want %d.%d", major, minor, DefaultMajorVersion, DefaultMinorVersion)
+	}
+	if n := len(f.sentCommands()); n > 2 {
+		t.Errorf("sent %d commands, expected to stop after the first version was accepted", n)
+	}
+}
+
+func TestConnectFailsCleanlyAgainstTooOldQTM(t *testing.T) {
+	// A QTM below the supported floor rejects every version in the ladder.
+	// Connect must fail and, critically, must leave the socket closed so a
+	// reconnect loop does not spin forever believing it is connected.
+	f := newFakeQTM(t)
+	f.handler = acceptVersion(1, 15)
+	f.start()
+
+	rt := NewProtocol("127.0.0.1", f.basePort())
+	err := rt.Connect()
+	if err == nil {
+		t.Fatal("expected connect to fail against an unsupported QTM")
+	}
+	if !errors.Is(err, ErrVersionNotSupported) {
+		t.Errorf("got %v, want ErrVersionNotSupported", err)
+	}
+	if rt.IsConnected() {
+		t.Error("IsConnected is true after a failed handshake; the socket leaked")
+	}
+}
+
+func TestWithoutVersionNegotiationTriesOnlyOne(t *testing.T) {
+	f := newFakeQTM(t)
+	f.handler = acceptVersion(1, 25)
+	f.start()
+
+	rt := NewProtocol("127.0.0.1", f.basePort(),
+		WithVersion(1, 28), WithoutVersionNegotiation())
+	if err := rt.Connect(); err == nil {
+		t.Fatal("expected connect to fail with negotiation disabled")
+	}
+	if cmds := f.sentCommands(); len(cmds) != 1 {
+		t.Errorf("sent %v, want exactly one version attempt", cmds)
+	}
+}
+
+func TestReceiveHandlesHeaderSplitAcrossWrites(t *testing.T) {
+	// TCP may deliver fewer than 8 bytes on the first read. The previous
+	// implementation treated that as a fatal "packet too small for header".
+	f := newFakeQTM(t)
+	f.welcome = nil
+	f.onConn = func(conn net.Conn) {
+		pkt := commandPacket("QTM RT Interface connected")
+		for _, chunk := range [][]byte{pkt[:3], pkt[3:6], pkt[6:]} {
+			conn.Write(chunk)
+			time.Sleep(10 * time.Millisecond)
+		}
+		time.Sleep(time.Second)
+	}
+	f.start()
+
+	rt := NewProtocol("127.0.0.1", f.basePort(), WithReadTimeout(2*time.Second))
+	conn, err := net.Dial("tcp", f.listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	rt.conn = conn
+
+	p, err := rt.Receive()
+	if err != nil {
+		t.Fatalf("receive: %v", err)
+	}
+	if p.CommandResponse != "QTM RT Interface connected" {
+		t.Errorf("got %q", p.CommandResponse)
+	}
+}
+
+func TestReceiveReportsTruncatedPacket(t *testing.T) {
+	// A packet header promising more data than ever arrives must be an error.
+	// Returning NoMoreData here, as the old code did, left the partial body in
+	// the socket to be misread as the next packet header.
+	f := newFakeQTM(t)
+	f.welcome = nil
+	f.onConn = func(conn net.Conn) {
+		full := commandPacket("this response never fully arrives")
+		conn.Write(full[:12]) // header plus a few bytes only
+		time.Sleep(2 * time.Second)
+	}
+	f.start()
+
+	rt := NewProtocol("127.0.0.1", f.basePort(), WithReadTimeout(200*time.Millisecond))
+	conn, err := net.Dial("tcp", f.listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	rt.conn = conn
+
+	_, err = rt.Receive()
+	if !errors.Is(err, ErrTruncated) {
+		t.Errorf("got %v, want ErrTruncated", err)
+	}
+}
+
+func TestReceiveRejectsAbsurdPacketSize(t *testing.T) {
+	f := newFakeQTM(t)
+	f.welcome = nil
+	f.onConn = func(conn net.Conn) {
+		b := make([]byte, packetHeaderSize)
+		binary.LittleEndian.PutUint32(b[0:4], 0xFFFFFFF0)
+		binary.LittleEndian.PutUint32(b[4:8], uint32(PacketTypeCommand))
+		conn.Write(b)
+		time.Sleep(time.Second)
+	}
+	f.start()
+
+	rt := NewProtocol("127.0.0.1", f.basePort(), WithMaxPacketSize(1<<20))
+	conn, err := net.Dial("tcp", f.listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	rt.conn = conn
+
+	if _, err := rt.Receive(); err == nil {
+		t.Error("expected an error for a packet size beyond the configured limit")
+	}
+}
+
+func TestReceiveTimeoutYieldsNoMoreData(t *testing.T) {
+	f := newFakeQTM(t)
+	f.welcome = nil
+	f.onConn = func(conn net.Conn) { time.Sleep(time.Second) }
+	f.start()
+
+	rt := NewProtocol("127.0.0.1", f.basePort(), WithReadTimeout(50*time.Millisecond))
+	conn, err := net.Dial("tcp", f.listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	rt.conn = conn
+
+	p, err := rt.Receive()
+	if err != nil {
+		t.Fatalf("a quiet socket should not be an error: %v", err)
+	}
+	if !p.EndOfData() {
+		t.Errorf("got %v, want PacketTypeNoMoreData", p.Type)
+	}
+}
+
+func TestCommandsSkipInterleavedEvents(t *testing.T) {
+	// QTM pushes events asynchronously. The old implementation took the first
+	// packet it saw as the command response, so an event arriving mid-command
+	// made TakeControl and friends fail for no reason.
+	f := newFakeQTM(t)
+	f.handler = func(cmd string) []byte {
+		switch {
+		case strings.HasPrefix(cmd, "Version "):
+			return commandPacket("Version set to 1.28")
+		case cmd == "GetState":
+			return eventPacket(EventTypeConnected)
+		case cmd == "TakeControl":
+			reply := eventPacket(EventTypeCaptureStarted)
+			reply = append(reply, eventPacket(EventTypeWaitingForTrigger)...)
+			reply = append(reply, commandPacket("You are now master")...)
+			return reply
+		}
+		return nil
+	}
+	f.start()
+
+	rt := NewProtocol("127.0.0.1", f.basePort())
+	if err := rt.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer rt.Disconnect()
+
+	if err := rt.TakeControl(""); err != nil {
+		t.Fatalf("TakeControl should skip the interleaved events: %v", err)
+	}
+	if got := rt.State(); got != EventTypeWaitingForTrigger {
+		t.Errorf("State = %v, want the last skipped event to be recorded", got)
+	}
+}
+
+func TestTakeControlOmitsEmptyPassword(t *testing.T) {
+	// "TakeControl " with a trailing space was previously sent when no password
+	// was supplied.
+	f := newFakeQTM(t)
+	f.handler = func(cmd string) []byte {
+		if strings.HasPrefix(cmd, "Version ") {
+			return commandPacket("Version set to 1.28")
+		}
+		if cmd == "GetState" {
+			return eventPacket(EventTypeConnected)
+		}
+		return commandPacket("You are now master")
+	}
+	f.start()
+
+	rt := NewProtocol("127.0.0.1", f.basePort())
+	if err := rt.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer rt.Disconnect()
+	if err := rt.TakeControl(""); err != nil {
+		t.Fatalf("takecontrol: %v", err)
+	}
+
+	if !f.waitForCommand("TakeControl", 2*time.Second) {
+		t.Fatalf("commands = %v, want a bare TakeControl", f.sentCommands())
+	}
+	for _, c := range f.sentCommands() {
+		if c == "TakeControl " {
+			t.Error("sent TakeControl with a trailing space")
+		}
+	}
+}
+
+func TestGetParametersSkipsEvents(t *testing.T) {
+	f := newFakeQTM(t)
+	f.handler = func(cmd string) []byte {
+		switch {
+		case strings.HasPrefix(cmd, "Version "):
+			return commandPacket("Version set to 1.28")
+		case cmd == "GetState":
+			return eventPacket(EventTypeConnected)
+		case strings.HasPrefix(cmd, "GetParameters"):
+			reply := eventPacket(EventTypeCameraSettingsChanged)
+			reply = append(reply, xmlPacket("<QTM_Parameters_Ver_1.28><The_3D/></QTM_Parameters_Ver_1.28>")...)
+			return reply
+		}
+		return nil
+	}
+	f.start()
+
+	rt := NewProtocol("127.0.0.1", f.basePort())
+	if err := rt.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer rt.Disconnect()
+
+	xml, err := rt.GetParameters(ParameterType3D)
+	if err != nil {
+		t.Fatalf("getparameters: %v", err)
+	}
+	if !strings.Contains(xml, "The_3D") {
+		t.Errorf("got %q", xml)
+	}
+}
+
+func TestGetParametersSkeletonGlobalOption(t *testing.T) {
+	f := newFakeQTM(t)
+	f.handler = func(cmd string) []byte {
+		switch {
+		case strings.HasPrefix(cmd, "Version "):
+			return commandPacket("Version set to 1.28")
+		case cmd == "GetState":
+			return eventPacket(EventTypeConnected)
+		case strings.HasPrefix(cmd, "GetParameters"):
+			return xmlPacket("<x/>")
+		}
+		return nil
+	}
+	f.start()
+
+	rt := NewProtocol("127.0.0.1", f.basePort())
+	if err := rt.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer rt.Disconnect()
+
+	if _, err := rt.GetParametersWithOptions(
+		ParameterOptions{SkeletonGlobal: true}, ParameterTypeSkeleton); err != nil {
+		t.Fatalf("getparameters: %v", err)
+	}
+
+	if !f.waitForCommand("GetParameters Skeleton:global", 2*time.Second) {
+		t.Errorf("commands = %v, want GetParameters Skeleton:global", f.sentCommands())
+	}
+}
+
+func TestParametersElementNameTracksNegotiatedVersion(t *testing.T) {
+	f := newFakeQTM(t)
+	f.handler = acceptVersion(1, 24)
+	f.start()
+
+	rt := NewProtocol("127.0.0.1", f.basePort())
+	if err := rt.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer rt.Disconnect()
+
+	if got := rt.ParametersElementName(); got != "QTM_Parameters_Ver_1.24" {
+		t.Errorf("got %q, want QTM_Parameters_Ver_1.24", got)
+	}
+
+	xml := "<QTM_Parameters_Ver_1.24><The_6D/></QTM_Parameters_Ver_1.24>"
+	if got := rt.StripParametersElement(xml); got != "<The_6D/>" {
+		t.Errorf("strip returned %q", got)
+	}
+}
+
+func TestOperationsOnClosedConnection(t *testing.T) {
+	rt := NewProtocol("127.0.0.1", 22222)
+	if _, err := rt.Receive(); !errors.Is(err, ErrNotConnected) {
+		t.Errorf("Receive: got %v, want ErrNotConnected", err)
+	}
+	if err := rt.StreamFramesAll(ComponentType3D); !errors.Is(err, ErrNotConnected) {
+		t.Errorf("StreamFramesAll: got %v, want ErrNotConnected", err)
+	}
+	if _, err := rt.GetParameters(ParameterType3D); !errors.Is(err, ErrNotConnected) {
+		t.Errorf("GetParameters: got %v, want ErrNotConnected", err)
+	}
+}
+
+func TestReceiveReturnsNonNilPacketOnError(t *testing.T) {
+	// The bundled examples inspect the returned packet before checking the
+	// error, so a nil packet alongside an error would panic in user code.
+	rt := NewProtocol("127.0.0.1", 22222)
+	p, err := rt.Receive()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if p == nil {
+		t.Fatal("Receive returned a nil packet alongside an error")
+	}
+	_ = p.EndOfData()
+}

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -130,7 +130,7 @@ func (f *fakeQTM) sentCommands() []string {
 
 // waitForCommand polls until cmd has been received or the deadline passes.
 // Fire-and-forget commands such as StreamFrames send no reply, so the test has
-// no response to synchronise on.
+// no response to synchronize on.
 func (f *fakeQTM) waitForCommand(cmd string, within time.Duration) bool {
 	deadline := time.Now().Add(within)
 	for time.Now().Before(deadline) {
@@ -262,7 +262,9 @@ func TestReceiveHandlesHeaderSplitAcrossWrites(t *testing.T) {
 	f.onConn = func(conn net.Conn) {
 		pkt := commandPacket("QTM RT Interface connected")
 		for _, chunk := range [][]byte{pkt[:3], pkt[3:6], pkt[6:]} {
-			conn.Write(chunk)
+			if _, err := conn.Write(chunk); err != nil {
+				return
+			}
 			time.Sleep(10 * time.Millisecond)
 		}
 		time.Sleep(time.Second)
@@ -294,7 +296,9 @@ func TestReceiveReportsTruncatedPacket(t *testing.T) {
 	f.welcome = nil
 	f.onConn = func(conn net.Conn) {
 		full := commandPacket("this response never fully arrives")
-		conn.Write(full[:12]) // header plus a few bytes only
+		if _, err := conn.Write(full[:12]); err != nil { // header plus a few bytes only
+			return
+		}
 		time.Sleep(2 * time.Second)
 	}
 	f.start()
@@ -320,7 +324,9 @@ func TestReceiveRejectsAbsurdPacketSize(t *testing.T) {
 		b := make([]byte, packetHeaderSize)
 		binary.LittleEndian.PutUint32(b[0:4], 0xFFFFFFF0)
 		binary.LittleEndian.PutUint32(b[4:8], uint32(PacketTypeCommand))
-		conn.Write(b)
+		if _, err := conn.Write(b); err != nil {
+			return
+		}
 		time.Sleep(time.Second)
 	}
 	f.start()
@@ -341,7 +347,7 @@ func TestReceiveRejectsAbsurdPacketSize(t *testing.T) {
 func TestReceiveTimeoutYieldsNoMoreData(t *testing.T) {
 	f := newFakeQTM(t)
 	f.welcome = nil
-	f.onConn = func(conn net.Conn) { time.Sleep(time.Second) }
+	f.onConn = func(_ net.Conn) { time.Sleep(time.Second) }
 	f.start()
 
 	rt := NewProtocol("127.0.0.1", f.basePort(), WithReadTimeout(50*time.Millisecond))

--- a/udp_helper_test.go
+++ b/udp_helper_test.go
@@ -1,0 +1,12 @@
+package qualisys
+
+import "net"
+
+type netConn interface {
+	Write([]byte) (int, error)
+	Close() error
+}
+
+func dialUDPLoopback(port int) (netConn, error) {
+	return net.DialUDP("udp", nil, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port})
+}


### PR DESCRIPTION
- **fix(packets): bounds-check decoding and repair parser defects**
- **fix(protocol): harden packet framing and connection lifecycle**
- **feat(protocol): negotiate RT versions to 1.28 and close command gaps**
- **test: cover parsers, framing, version negotiation and drop gotest.tools**
- **docs: update examples and README for the new API**
- **feat: preserve undecodable components and add an accessor per component**
- **feat: harden discovery and fill in small API gaps**
- **docs: compile every README example as a testable example**
