### PR TITLE
ci: derive the Go version from .sage/go.mod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Sage
         uses: einride/sage/actions/setup@master
         with:
-          go-version: '1.23.0'
+          go-version-file: .sage/go.mod
 
       - name: Make
         run: make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Sage
         uses: einride/sage/actions/setup@master
         with:
-          go-version: '1.23.0'
+          go-version-file: .sage/go.mod
 
       - name: Make
         run: make

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ func main() {
 
 - It should always fail to connect to older QTM version (Support 1.22 and
   upwards)
-- StreamFrames - Missing support for \[:channels\] handling.
+- StreamFrames - Missing support for [:channels] handling.


### PR DESCRIPTION
## What

Both `ci.yaml` and `release.yml` pinned `go-version: '1.23.0'` when calling `einride/sage/actions/setup`. They now read the version from `.sage/go.mod` instead:

```yaml
- name: Setup Sage
  uses: einride/sage/actions/setup@master
  with:
    go-version-file: .sage/go.mod
```

## Why

Sage bumped its own `go` directive from `1.22` to `1.24.9` in v0.381.0. From that release on, the Makefile bootstrap — `cd .sage && go mod tidy && go run .` — cannot build with the toolchain CI installs, so `make` dies before reaching any real work.

Every sage dependabot PR since has failed in roughly 20 seconds, and the run durations flip exactly at that version:

| sage version | `go` directive | run duration |
| --- | --- | --- |
| 0.377.3 | 1.22 | 55s |
| 0.380.0 | 1.22 | 48s |
| **0.381.0** | **1.24.9** | **16s** |
| 0.395.1 | 1.24.9 | 22s |

The runs before 0.381.0 were failing too, but later and for unrelated reasons. #125 has been red since February.

## Why `go-version-file` rather than a newer pin

Dependabot already keeps `.sage/go.mod` current, so deriving the version from it means the next sage bump that raises the floor won't need another workflow edit. `einride/sage/actions/setup` supports the input and skips its `go-version` branch when it is set.

On `master` today `.sage/go.mod` still says `go 1.23.0`, so CI installs exactly what it installs now — this is a no-op for `master` and carries no regression risk. On a sage-bump branch it reads `go 1.24.9` and installs that.

Pinning `go-version: '1.25'` would also unblock the bumps, but it moves `master` onto Go 1.25 while sage 0.327.1 still pins golangci-lint v1.61.0 — an untested pairing I'd rather not introduce in a fix whose job is to make CI work again.

## Reviewer notes

- **Not verified locally.** There's no Go toolchain on the machine this was written on, so `make` was never run. The diagnosis comes from the sage sources (`sg/makefile.go`, `go.mod` at each tag) and the run timings above. CI on this PR is the first real execution.
- **This does not fully green #125 on its own.** Once the toolchain is right, sage 0.395.1 will build and regenerate the `Makefile`, which will then differ from the committed one and fail `git-verify-no-diff`. The generator diff between v0.327.1 and v0.395.1 is two lines: `SAGE_GO_VERSION ?= 1.20.2` → `1.24.12`, and `update-sage` drops the `-d` from `go get -d`. That needs a local `make` run to regenerate and commit, plus whatever golangci-lint v2.x flags on existing code. Deliberately left out of this PR rather than hand-editing generated output that can't be verified here.
- **#126 is a different failure.** Its run reached `go-lint` and failed on 33 findings in that branch's own code. Unrelated to the toolchain; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
